### PR TITLE
Fix the SubpixelLocalization bias bug.

### DIFF
--- a/src/main/java/net/imglib2/algorithm/localextrema/SubpixelLocalization.java
+++ b/src/main/java/net/imglib2/algorithm/localextrema/SubpixelLocalization.java
@@ -442,7 +442,6 @@ public class SubpixelLocalization< P extends Localizable, T extends RealType< T 
 		final int n = p.numDimensions();
 
 		access.setPosition( p );
-
 		final double a1 = access.get().getRealDouble();
 		for ( int d = 0; d < n; ++d )
 		{
@@ -463,6 +462,9 @@ public class SubpixelLocalization< P extends Localizable, T extends RealType< T 
 			access.move( 2, d );
 			final double a2 = access.get().getRealDouble();
 			g.set( d, 0, ( a2 - a0 ) * 0.5 );
+
+			// Move back to center point
+			access.bck( d );
 
 			// @formatter:off
 			// Hessian
@@ -494,6 +496,8 @@ public class SubpixelLocalization< P extends Localizable, T extends RealType< T 
 			// we divide by 2 because these are always jumps over two pixels
 			for ( int e = d + 1; e < n; ++e )
 			{
+				// We start from center point.
+				access.fwd( d );
 				access.fwd( e );
 				final double a2b2 = access.get().getRealDouble();
 				access.move( -2, d );


### PR DESCRIPTION
The SubpixelLocalization class is based on quadratic fitting of the peak
it tries to localize. To retrieve an estimate of the position, we
compute the gradient and the hessian at the peak integer location.

To compute the gradient and hessian, we use a randomAccess on the peak
image, and iterate through dimensions.

It turns out that the randomAccess position was not restored at the peak
center after dealing with a dimension. Therefore, the next dimensions
were calculated off-peak.

Fixes #12.

Signed-off-by: Jean-Yves Tinevez <jean-yves.tinevez@pasteur.fr>