### PR TITLE
Specialized cursor for RectangleNeighborhoods

### DIFF
--- a/src/main/java/net/imglib2/algorithm/integral/IntegralCursor.java
+++ b/src/main/java/net/imglib2/algorithm/integral/IntegralCursor.java
@@ -1,0 +1,242 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.algorithm.integral;
+
+import java.util.Vector;
+
+import net.imglib2.AbstractEuclideanSpace;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
+
+/**
+ * A cursor implementation that returns specific corner values of
+ * {@link RectangleNeighborhood}s.
+ *
+ * The cursor returns, for example in 2D, the values at the following
+ * positions:
+ *
+ * <ol>
+ * <li>(neighMin, neighMin),</li>
+ * <li>(neighMax-1, neighMin),</li>
+ * <li>(neighMin, neighMax-1), and</li>
+ * <li>(neighMax-1, neighMax-1).</li>
+ * </ol>
+ *
+ * The mechanism naturally extends to nD. The current position can be
+ * obtained from {@code getVector()} with 0s encoding neighMin and 1s
+ * encoding neighMax-1.
+ *
+ * @author Stefan Helfrich
+ */
+public class IntegralCursor< T > extends AbstractEuclideanSpace implements Cursor< T >
+{
+
+	private int index = 0;
+
+	private final int maxIndex;
+
+	private final RandomAccess< T > source;
+
+	private final RectangleNeighborhood< T > neighborhood;
+
+	public IntegralCursor( final RectangleNeighborhood< T > neighborhood )
+	{
+		super( neighborhood.numDimensions() );
+		this.neighborhood = neighborhood;
+		source = neighborhood.getSourceRandomAccess();
+		maxIndex = ( int ) Math.round( Math.pow( 2, neighborhood.numDimensions() ) );
+		reset();
+	}
+
+	protected IntegralCursor( final IntegralCursor< T > cursor )
+	{
+		super( cursor.numDimensions() );
+		neighborhood = cursor.neighborhood; // FIXME?
+		source = cursor.source.copyRandomAccess();
+		index = cursor.index;
+		maxIndex = cursor.maxIndex;
+	}
+
+	@Override
+	public void reset()
+	{
+		long[] min = new long[ neighborhood.numDimensions() ];
+		neighborhood.min( min );
+		source.setPosition( min );
+		source.bck( 0 );
+		index = 0;
+	}
+
+	@Override
+	public void fwd()
+	{
+		// Extract each dimension individually from currentPosition
+		final long[] cornerPosition = new long[ neighborhood.numDimensions() ];
+		for ( int d = 0; d < neighborhood.numDimensions(); ++d )
+		{
+			int valueInDimension = index >> d;
+			valueInDimension = valueInDimension & 1;
+
+			if ( valueInDimension == 1 )
+			{
+				// if bit in dimension is set
+				cornerPosition[ d ] = neighborhood.max( d ) - 1;
+			}
+			else
+			{
+				// if not
+				cornerPosition[ d ] = neighborhood.min( d );
+			}
+		}
+
+		source.setPosition( cornerPosition );
+		++index;
+	}
+
+	@Override
+	public void jumpFwd( final long steps )
+	{
+		for ( long i = 0; i < steps; ++i )
+			fwd();
+	}
+
+	@Override
+	public T get()
+	{
+		return source.get();
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		return index < maxIndex;
+	}
+
+	@Override
+	public T next()
+	{
+		fwd();
+		return get();
+	}
+
+	@Override
+	public IntegralCursor< T > copy()
+	{
+		return new IntegralCursor< T >( this );
+	}
+
+	@Override
+	public IntegralCursor< T > copyCursor()
+	{
+		return copy();
+	}
+
+	public int getCornerInteger()
+	{
+		return index;
+	}
+
+	public Vector< Integer > getCornerVector()
+	{
+		final Vector< Integer > vec = new Vector< Integer >();
+
+		// Extract each dimension individually from currentPosition
+		for ( int d = 0; d < neighborhood.numDimensions(); ++d )
+		{
+			int valueInDimension = index >> d;
+			valueInDimension = valueInDimension & 1;
+
+			vec.add( valueInDimension );
+		}
+
+		return vec;
+	}
+
+	@Override
+	public void remove()
+	{
+		// NB: no action.
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return source.getFloatPosition( d );
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return source.getDoublePosition( d );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return source.getIntPosition( d );
+	}
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return source.getLongPosition( d );
+	}
+
+	@Override
+	public void localize( final long[] position )
+	{
+		source.localize( position );
+	}
+
+	@Override
+	public void localize( final float[] position )
+	{
+		source.localize( position );
+	}
+
+	@Override
+	public void localize( final double[] position )
+	{
+		source.localize( position );
+	}
+
+	@Override
+	public void localize( final int[] position )
+	{
+		source.localize( position );
+	}
+
+}

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
@@ -221,6 +221,7 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 	{
 		return cursor();
 	}
+	
 
 	public final class LocalCursor extends AbstractEuclideanSpace implements Cursor< T >
 	{
@@ -367,4 +368,138 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 			return copy();
 		}
 	}
+	
+	public IntegralCursor integralCursor()
+	{
+		return new IntegralCursor( sourceRandomAccess.copyRandomAccess() );
+	}
+
+	private enum IntegralPosition {
+		NONE,
+		A,
+		B,
+		C,
+		D;
+	}
+	
+	public class IntegralCursor extends AbstractEuclideanSpace implements Cursor<T> {
+
+		private final RandomAccess<T> source;
+
+		private long index;
+
+		private IntegralPosition currentIntegralPosition;
+		
+		public IntegralCursor(final RandomAccess<T> source) {
+			super(source.numDimensions());
+			this.source = source;
+			reset();
+		}
+
+		protected IntegralCursor(final IntegralCursor c) {
+			super(c.numDimensions());
+			source = c.source.copyRandomAccess();
+			index = c.index;
+			currentIntegralPosition = c.currentIntegralPosition;
+		}
+
+		@Override
+		public T get() {
+			return source.get();
+		}
+
+		@Override
+		public void fwd() {
+			switch (currentIntegralPosition) {
+				case NONE: source.setPosition(currentMin); currentIntegralPosition = IntegralPosition.A; break;
+				case A: source.setPosition(new long[]{currentMax[0]-1, currentMin[1]}); currentIntegralPosition = IntegralPosition.B; break;
+				case B: source.setPosition(new long[]{currentMin[0], currentMax[1]-1}); currentIntegralPosition = IntegralPosition.C; break;
+				case C: source.setPosition(new long[]{currentMax[0]-1, currentMax[1]-1}); currentIntegralPosition = IntegralPosition.D; break;
+				case D: source.setPosition(currentMin); break;
+			}
+		}
+
+		@Override
+		public void jumpFwd(final long steps) {
+			// TODO Implement
+			for (long i = 0; i < steps; ++i)
+				fwd();
+		}
+
+		@Override
+		public T next() {
+			fwd();
+			return get();
+		}
+
+		@Override
+		public void remove() {
+			// NB: no action.
+		}
+
+		@Override
+		public void reset() {
+			source.setPosition(currentMin);
+			currentIntegralPosition = IntegralPosition.NONE;
+			source.bck(0);
+			index = 0;
+		}
+
+		@Override
+		public boolean hasNext() {
+			// FIXME
+			return index < maxIndex;
+		}
+
+		@Override
+		public float getFloatPosition(final int d) {
+			return source.getFloatPosition(d);
+		}
+
+		@Override
+		public double getDoublePosition(final int d) {
+			return source.getDoublePosition(d);
+		}
+
+		@Override
+		public int getIntPosition(final int d) {
+			return source.getIntPosition(d);
+		}
+
+		@Override
+		public long getLongPosition(final int d) {
+			return source.getLongPosition(d);
+		}
+
+		@Override
+		public void localize(final long[] position) {
+			source.localize(position);
+		}
+
+		@Override
+		public void localize(final float[] position) {
+			source.localize(position);
+		}
+
+		@Override
+		public void localize(final double[] position) {
+			source.localize(position);
+		}
+
+		@Override
+		public void localize(final int[] position) {
+			source.localize(position);
+		}
+
+		@Override
+		public IntegralCursor copy() {
+			return new IntegralCursor(this);
+		}
+
+		@Override
+		public IntegralCursor copyCursor() {
+			return copy();
+		}
+	}
+	
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
@@ -35,7 +35,6 @@
 package net.imglib2.algorithm.neighborhood;
 
 import java.util.Iterator;
-import java.util.Vector;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractLocalizable;
@@ -92,6 +91,14 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 	public Interval getStructuringElementBoundingBox()
 	{
 		return structuringElementBoundingBox;
+	}
+
+	/**
+	 * @return the sourceRandomAccess
+	 */
+	public RandomAccess< T > getSourceRandomAccess()
+	{
+		return sourceRandomAccess;
 	}
 
 	@Override
@@ -223,7 +230,7 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		return cursor();
 	}
 
-	public class LocalCursor extends AbstractEuclideanSpace implements Cursor< T >
+	public final class LocalCursor extends AbstractEuclideanSpace implements Cursor< T >
 	{
 		private final RandomAccess< T > source;
 
@@ -366,133 +373,6 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		public LocalCursor copyCursor()
 		{
 			return copy();
-		}
-
-		/**
-		 * @return the source
-		 */
-		public RandomAccess< T > getSource()
-		{
-			return source;
-		}
-	}
-
-	public IntegralCursor integralCursor()
-	{
-		return new IntegralCursor( sourceRandomAccess.copyRandomAccess() );
-	}
-
-	/**
-	 * A cursor implementation that returns specific corner values of
-	 * {@link RectangleNeighborhood}s.
-	 *
-	 * The cursor returns, for example in 2D, the values at the following
-	 * positions:
-	 *
-	 * <ol>
-	 * <li>(neighMin, neighMin),</li>
-	 * <li>(neighMax-1, neighMin),</li>
-	 * <li>(neighMin, neighMax-1), and</li>
-	 * <li>(neighMax-1, neighMax-1).</li>
-	 * </ol>
-	 *
-	 * The mechanism naturally extends to nD. The current position can be
-	 * obtained from {@code getVector()} with 0s encoding neighMin and 1s
-	 * encoding neighMax-1.
-	 *
-	 * @author Stefan Helfrich
-	 */
-	public class IntegralCursor extends LocalCursor
-	{
-
-		// Refrain from using index to make the separation clear
-		private int currentPosition = 0;
-
-		private int maxPosition = 0;
-
-		public IntegralCursor( final RandomAccess< T > source )
-		{
-			super( source );
-			maxPosition = ( int ) Math.round( Math.pow( 2, currentMin.length ) );
-		}
-
-		protected IntegralCursor( final IntegralCursor c )
-		{
-			super( c );
-			currentPosition = c.currentPosition;
-			maxPosition = c.maxPosition;
-		}
-
-		@Override
-		public void fwd()
-		{
-			// Extract each dimension individually from currentPosition
-			final long[] cornerPosition = new long[ currentMin.length ];
-			for ( int d = 0; d < currentMin.length; ++d )
-			{
-				int valueInDimension = currentPosition >> d;
-				valueInDimension = valueInDimension & 1;
-
-				if ( valueInDimension == 1 )
-				{
-					// if bit in dimension is set
-					cornerPosition[ d ] = currentMax[ d ] - 1;
-				}
-				else
-				{
-					// if not
-					cornerPosition[ d ] = currentMin[ d ];
-				}
-			}
-
-			getSource().setPosition( cornerPosition );
-			++currentPosition;
-		}
-
-		@Override
-		public void reset()
-		{
-			super.reset();
-			currentPosition = 0;
-		}
-
-		@Override
-		public boolean hasNext()
-		{
-			return currentPosition < maxPosition;
-		}
-
-		@Override
-		public IntegralCursor copy()
-		{
-			return new IntegralCursor( this );
-		}
-
-		@Override
-		public IntegralCursor copyCursor()
-		{
-			return copy();
-		}
-
-		public int getCornerInteger()
-		{
-			return currentPosition;
-		}
-
-		public Vector< Integer > getCornerVector()
-		{
-			final Vector< Integer > vec = new Vector< Integer >();
-
-			// Extract each dimension individually from currentPosition
-			for ( int d = 0; d < currentMin.length; ++d )
-			{
-				int valueInDimension = currentPosition >> d;
-				valueInDimension = valueInDimension & 1;
-
-				vec.add( valueInDimension );
-			}
-
-			return vec;
 		}
 	}
 

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
@@ -383,6 +383,26 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		return new IntegralCursor( sourceRandomAccess.copyRandomAccess() );
 	}
 
+	/**
+	 * A cursor implementation that returns specific corner values of
+	 * {@link RectangleNeighborhood}s.
+	 * 
+	 * The cursor returns, for example in 2D, the values at the following
+	 * positions:
+	 * 
+	 * <ol>
+	 * <li>(neighMin, neighMin),</li>
+	 * <li>(neighMax-1, neighMin),</li>
+	 * <li>(neighMin, neighMax-1), and</li>
+	 * <li>(neighMax-1, neighMax-1).</li>
+	 * </ol>
+	 * 
+	 * The mechanism naturally extends to nD. The current position can be
+	 * obtained from {@code getVector()} with 0s encoding neighMin and 1s
+	 * encoding neighMax-1.
+	 * 
+	 * @author Stefan Helfrich
+	 */
 	public class IntegralCursor extends LocalCursor
 	{
 

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
@@ -35,6 +35,7 @@
 package net.imglib2.algorithm.neighborhood;
 
 import java.util.Iterator;
+import java.util.Vector;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractLocalizable;
@@ -376,64 +377,103 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 			return source;
 		}
 	}
-	
+
 	public IntegralCursor integralCursor()
 	{
 		return new IntegralCursor( sourceRandomAccess.copyRandomAccess() );
 	}
 
-	private enum IntegralPosition {
-		UNINITIALIZED,
-		A,
-		B,
-		C,
-		D;
-	}
-	
-	public class IntegralCursor extends LocalCursor {
+	public class IntegralCursor extends LocalCursor
+	{
 
-		private IntegralPosition currentIntegralPosition;
+		// Refrain from using index to make the separation clear
+		private int currentPosition = 0;
+		private int maxPosition = 0;
 
-		public IntegralCursor(final RandomAccess<T> source) {
-			super(source);
+		public IntegralCursor( final RandomAccess< T > source )
+		{
+			super( source );
+			maxPosition = (int) Math.round( Math.pow( 2, currentMin.length ) );
 		}
 
-		protected IntegralCursor(final IntegralCursor c) {
-			super(c);
-			currentIntegralPosition = c.currentIntegralPosition;
+		protected IntegralCursor( final IntegralCursor c )
+		{
+			super( c );
+			currentPosition = c.currentPosition;
+			maxPosition = c.maxPosition;
 		}
 
 		@Override
-		public void fwd() {
-			switch (currentIntegralPosition) {
-				case UNINITIALIZED: getSource().setPosition(currentMin); currentIntegralPosition = IntegralPosition.A; break;
-				case A: getSource().setPosition(new long[]{currentMax[0]-1, currentMin[1]}); currentIntegralPosition = IntegralPosition.B; break;
-				case B: getSource().setPosition(new long[]{currentMin[0], currentMax[1]-1}); currentIntegralPosition = IntegralPosition.C; break;
-				case C: getSource().setPosition(new long[]{currentMax[0]-1, currentMax[1]-1}); currentIntegralPosition = IntegralPosition.D; break;
-				case D: getSource().setPosition(currentMin); break;
+		public void fwd()
+		{
+			// Extract each dimension individually from currentPosition
+			long[] cornerPosition = new long[ currentMin.length ];
+			for ( int d = 0; d < currentMin.length; ++d )
+			{
+				int valueInDimension = currentPosition >> d;
+				valueInDimension = valueInDimension & 1;
+
+				if ( valueInDimension == 1 )
+				{
+					// if bit in dimension is set
+					cornerPosition[ d ] = currentMax[ d ] - 1;
+				}
+				else
+				{
+					// if not
+					cornerPosition[ d ] = currentMin[ d ];
+				}
 			}
+
+			getSource().setPosition( cornerPosition );
+			++currentPosition;
 		}
 
 		@Override
-		public void reset() {
+		public void reset()
+		{
 			super.reset();
-			currentIntegralPosition = IntegralPosition.UNINITIALIZED;
+			currentPosition = 0;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return currentIntegralPosition.ordinal() < IntegralPosition.values().length;
+		public boolean hasNext()
+		{
+			return currentPosition < maxPosition;
 		}
 
 		@Override
-		public IntegralCursor copy() {
-			return new IntegralCursor(this);
+		public IntegralCursor copy()
+		{
+			return new IntegralCursor( this );
 		}
 
 		@Override
-		public IntegralCursor copyCursor() {
+		public IntegralCursor copyCursor()
+		{
 			return copy();
 		}
+
+		public int getCornerInteger()
+		{
+			return currentPosition;
+		}
+		
+		public Vector< Integer > getCornerVector()
+		{
+			Vector< Integer > vec = new Vector< Integer >();
+
+			// Extract each dimension individually from currentPosition
+			for ( int d = 0; d < currentMin.length; ++d )
+			{
+				int valueInDimension = currentPosition >> d;
+				valueInDimension = valueInDimension & 1;
+
+				vec.add( valueInDimension );
+			}
+
+			return vec;
+		}
 	}
-	
+
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleNeighborhood.java
@@ -222,7 +222,6 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 	{
 		return cursor();
 	}
-	
 
 	public class LocalCursor extends AbstractEuclideanSpace implements Cursor< T >
 	{
@@ -368,7 +367,7 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		{
 			return copy();
 		}
-		
+
 		/**
 		 * @return the source
 		 */
@@ -386,21 +385,21 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 	/**
 	 * A cursor implementation that returns specific corner values of
 	 * {@link RectangleNeighborhood}s.
-	 * 
+	 *
 	 * The cursor returns, for example in 2D, the values at the following
 	 * positions:
-	 * 
+	 *
 	 * <ol>
 	 * <li>(neighMin, neighMin),</li>
 	 * <li>(neighMax-1, neighMin),</li>
 	 * <li>(neighMin, neighMax-1), and</li>
 	 * <li>(neighMax-1, neighMax-1).</li>
 	 * </ol>
-	 * 
+	 *
 	 * The mechanism naturally extends to nD. The current position can be
 	 * obtained from {@code getVector()} with 0s encoding neighMin and 1s
 	 * encoding neighMax-1.
-	 * 
+	 *
 	 * @author Stefan Helfrich
 	 */
 	public class IntegralCursor extends LocalCursor
@@ -408,12 +407,13 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 
 		// Refrain from using index to make the separation clear
 		private int currentPosition = 0;
+
 		private int maxPosition = 0;
 
 		public IntegralCursor( final RandomAccess< T > source )
 		{
 			super( source );
-			maxPosition = (int) Math.round( Math.pow( 2, currentMin.length ) );
+			maxPosition = ( int ) Math.round( Math.pow( 2, currentMin.length ) );
 		}
 
 		protected IntegralCursor( final IntegralCursor c )
@@ -427,7 +427,7 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		public void fwd()
 		{
 			// Extract each dimension individually from currentPosition
-			long[] cornerPosition = new long[ currentMin.length ];
+			final long[] cornerPosition = new long[ currentMin.length ];
 			for ( int d = 0; d < currentMin.length; ++d )
 			{
 				int valueInDimension = currentPosition >> d;
@@ -478,10 +478,10 @@ public class RectangleNeighborhood< T > extends AbstractLocalizable implements N
 		{
 			return currentPosition;
 		}
-		
+
 		public Vector< Integer > getCornerVector()
 		{
-			Vector< Integer > vec = new Vector< Integer >();
+			final Vector< Integer > vec = new Vector< Integer >();
 
 			// Extract each dimension individually from currentPosition
 			for ( int d = 0; d < currentMin.length; ++d )


### PR DESCRIPTION
The `IntegralCursor` returns specific corner values of `RectangleNeighborhood`s that can be used for computations on integral images. 

In the 2D example the values at the following positions are returned by `IntegralCursor`:
* (neighMin, neighMin)
* (neighMax-1, neighMin)
* (neighMin, neighMax-1)
* (neighMax-1, neighMax-1)

I would rather have it return the values at the corner positions (and call it CornerCursor) but that renders it effectively useless for use with local operations on integral images. The problem is that for computing the mean in a `RectangleNeighborhood` of an image, values from a `RectangleNeighborhood` with `span+1` at the positions returned by the `IntegralCursor` are required.
