### PR TITLE
Change visibility of MorphologyUtils methods

### DIFF
--- a/src/main/java/net/imglib2/algorithm/morphology/MorphologyUtils.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/MorphologyUtils.java
@@ -52,7 +52,7 @@ public class MorphologyUtils
 	 *         source image.
 	 *         </ol>
 	 */
-	static final < T > long[][] computeTargetImageDimensionsAndOffset( final Interval source, final Shape strel )
+	public static final < T > long[][] computeTargetImageDimensionsAndOffset( final Interval source, final Shape strel )
 	{
 		/*
 		 * Compute target image size


### PR DESCRIPTION
Methods with package visibility are changed to be public, so that other packages/projects could use.