### PR TITLE
Flood Fill for RandomAccessible

### DIFF
--- a/src/main/java/net/imglib2/algorithm/fill/FillPolicy.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FillPolicy.java
@@ -1,0 +1,17 @@
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.neighborhood.Shape;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ *
+ * Policy for filling and selecting neighbors in {@link FloodFill#fill(RandomAccessible, Localizable, Shape, FillPolicy)}.
+ *
+ */
+public interface FillPolicy< T > {
+    void fill( T t );
+
+    boolean isValidNeighbor( T t );
+}

--- a/src/main/java/net/imglib2/algorithm/fill/FillPolicyFactory.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FillPolicyFactory.java
@@ -1,0 +1,10 @@
+package net.imglib2.algorithm.fill;
+
+/**
+ * Created by hanslovskyp on 4/21/16.
+ */
+public interface FillPolicyFactory< T > {
+
+    FillPolicy< T > call( T t );
+
+}

--- a/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
@@ -86,33 +86,4 @@ public class FloodFill {
         }
     }
 
-
-//    public static void main(String[] args) {
-//        long[] dim = {120, 90};
-//
-//        long[] circle = { 40, 50, 30 }; // x, y, r
-//
-//        ArrayImg<LongType, LongArray> img = ArrayImgs.longs(dim);
-//        ArrayCursor<LongType> c;
-//        for(c = img.cursor(); c.hasNext(); )
-//        {
-//            c.fwd();
-//            long x = c.getLongPosition(0) - circle[0];
-//            long y = c.getLongPosition(1) - circle[1];
-//            if ( x*x + y*y <= circle[2]*circle[2] && ( y < 10 || y > 12 ) )
-//                c.get().set( 5 );
-//
-//        }
-//
-//
-//        new ImageJ();
-//        ImageJFunctions.show( img.copy() );
-//
-//        LongType seedType = new LongType(5);
-//        LongType newType = new LongType(8);
-//        GenericTypeFillPolicy<LongType> filler = new GenericTypeFillPolicy<LongType>(seedType, newType);
-//        fill( img, new Point( circle[0], circle[1] ), new DiamondShape(1), filler );
-//        ImageJFunctions.show( img );
-//    }
-
 }

--- a/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
@@ -1,0 +1,96 @@
+package net.imglib2.algorithm.fill;
+
+import gnu.trove.list.array.TLongArrayList;
+import net.imglib2.Cursor;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.Shape;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * Flood fill {@link RandomAccessible} of arbitrary dimension.
+ */
+public class FloodFill {
+
+    /**
+     *
+     * @param randomAccessible input (also written into)
+     * @param seed flood fill starting at this location
+     * @param shape neighborhood that is checked for filling
+     * @param filler policy for deciding whether or not neighbor is part of connected component and instructions on how to fill a pixel
+     * @param <T> no restrictions on T as long as appropriate {@link FillPolicy} is provided
+     */
+    public static < T > void fill(
+            final RandomAccessible< T > randomAccessible,
+            final Localizable seed,
+            final Shape shape,
+            final FillPolicy< T > filler )
+    {
+        final int n = randomAccessible.numDimensions();
+
+        final TLongArrayList[] coordinates = new TLongArrayList[ n ];
+        for ( int d = 0; d < n; ++d )
+        {
+            coordinates[ d ] = new TLongArrayList();
+            coordinates[ d ].add( seed.getLongPosition( d ) );
+        }
+
+        RandomAccessible<Neighborhood<T>> neighborhood = shape.neighborhoodsRandomAccessible(randomAccessible);
+        final RandomAccess<Neighborhood<T>> neighborhoodAccess = neighborhood.randomAccess();
+
+        final RandomAccess< T > canvasAccess = randomAccessible.randomAccess();
+        canvasAccess.setPosition( seed );
+        filler.fill( canvasAccess.get() );
+
+        for ( int i = 0; i < coordinates[ 0 ].size(); ++i )
+        {
+            for ( int d = 0; d < n; ++d )
+                neighborhoodAccess.setPosition( coordinates[ d ].get( i ), d );
+
+            final Cursor<T> neighborhoodCursor = neighborhoodAccess.get().cursor();
+
+            while ( neighborhoodCursor.hasNext() )
+            {
+                final T t = neighborhoodCursor.next();
+                if ( filler.isValidNeighbor( t ) )
+                {
+                    filler.fill( t );
+                    for ( int d = 0; d < n; ++d )
+                        coordinates[ d ].add( neighborhoodCursor.getLongPosition( d ) );
+                }
+            }
+        }
+    }
+
+
+//    public static void main(String[] args) {
+//        long[] dim = {120, 90};
+//
+//        long[] circle = { 40, 50, 30 }; // x, y, r
+//
+//        ArrayImg<LongType, LongArray> img = ArrayImgs.longs(dim);
+//        ArrayCursor<LongType> c;
+//        for(c = img.cursor(); c.hasNext(); )
+//        {
+//            c.fwd();
+//            long x = c.getLongPosition(0) - circle[0];
+//            long y = c.getLongPosition(1) - circle[1];
+//            if ( x*x + y*y <= circle[2]*circle[2] && ( y < 10 || y > 12 ) )
+//                c.get().set( 5 );
+//
+//        }
+//
+//
+//        new ImageJ();
+//        ImageJFunctions.show( img.copy() );
+//
+//        LongType seedType = new LongType(5);
+//        LongType newType = new LongType(8);
+//        GenericTypeFillPolicy<LongType> filler = new GenericTypeFillPolicy<LongType>(seedType, newType);
+//        fill( img, new Point( circle[0], circle[1] ), new DiamondShape(1), filler );
+//        ImageJFunctions.show( img );
+//    }
+
+}

--- a/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
@@ -16,6 +16,28 @@ public class FloodFill {
 
     /**
      *
+     * convenience method to automatically determine filler policy from value at seed point
+     *
+     * @param randomAccessible input (also written into)
+     * @param seed flood fill starting at this location
+     * @param shape neighborhood that is checked for filling
+     * @param fillerFactory rule for creating {@link FillPolicy} from pixel located at seed
+     * @param <T> no restrictions on T as long as appropriate {@link FillPolicy} is provided
+     */
+    public static < T > void fill(
+            final RandomAccessible< T > randomAccessible,
+            final Localizable seed,
+            final Shape shape,
+            final FillPolicyFactory< T > fillerFactory )
+    {
+        RandomAccess<T> access = randomAccessible.randomAccess();
+        access.setPosition( seed );
+        fill( randomAccessible, seed, shape, fillerFactory.call( access.get() ) );
+    }
+
+
+    /**
+     *
      * @param randomAccessible input (also written into)
      * @param seed flood fill starting at this location
      * @param shape neighborhood that is checked for filling

--- a/src/main/java/net/imglib2/algorithm/fill/GenericTypeFillPolicy.java
+++ b/src/main/java/net/imglib2/algorithm/fill/GenericTypeFillPolicy.java
@@ -1,0 +1,30 @@
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.type.Type;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ *
+ * Implementation of {@link FillPolicy} for generic imglib {@link Type}
+ * Fills neighbor with {@link this#newType} if neighbor is equal to {@link this#seedType} and different from {@link this#newType}.
+ */
+public class GenericTypeFillPolicy<T extends Type<T>> implements FillPolicy<T> {
+
+    private final T seedType;
+    private final T newType;
+
+    public GenericTypeFillPolicy(T seedType, T newType) {
+        this.seedType = seedType;
+        this.newType = newType;
+    }
+
+    @Override
+    public void fill(T t) {
+        t.set( newType );
+    }
+
+    @Override
+    public boolean isValidNeighbor(T t) {
+        return t.equals( this.seedType ) && !t.equals( this.newType );
+    }
+}

--- a/src/main/java/net/imglib2/algorithm/fill/GenericTypeFillPolicy.java
+++ b/src/main/java/net/imglib2/algorithm/fill/GenericTypeFillPolicy.java
@@ -18,6 +18,21 @@ public class GenericTypeFillPolicy<T extends Type<T>> implements FillPolicy<T> {
         this.newType = newType;
     }
 
+    public static class Factory< U extends Type< U > > implements FillPolicyFactory< U >
+    {
+
+        private final U newType;
+
+        public Factory(U newType) {
+            this.newType = newType;
+        }
+
+        @Override
+        public GenericTypeFillPolicy<U> call(U seedType) {
+            return new GenericTypeFillPolicy<U>( seedType.copy(), newType );
+        }
+    }
+
     @Override
     public void fill(T t) {
         t.set( newType );

--- a/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
+++ b/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
@@ -1,0 +1,93 @@
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.LongType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by hanslovskyp on 4/21/16.
+ */
+public class FloodFillTest {
+
+    private static final long START_LABEL = 1;
+    private static final long FILL_LABEL = 2;
+    private static final int[] N_DIMS = { 1, 2, 3, 4 };
+    private static final int SIZE_OF_EACH_DIM = 30;
+
+
+    private static < T extends IntegerType < T > > void runTest(
+            int nDim,
+            int sizeOfEachDim,
+            ImgFactory< T > imageFactory,
+            FillPolicyFactory< T > fillPolicyFactory,
+            T t )
+    {
+        long[] dim = new long[nDim];
+        long[] c = new long[nDim];
+        long r = sizeOfEachDim / 4;
+        for ( int d = 0; d < nDim; ++d ) {
+            dim[d] = sizeOfEachDim;
+            c[d] = sizeOfEachDim / 3;
+        }
+
+        long divisionLine = r / 3;
+
+        Img<T> img = imageFactory.create(dim, t.copy() );
+        Img<T> refImg = imageFactory.create(dim, t.copy());
+
+        for (Cursor<T> i = img.cursor(), ref = refImg.cursor(); i.hasNext(); )
+        {
+            i.fwd();
+            ref.fwd();
+            long diffSum = 0;
+            for ( int d = 0; d < nDim; ++d )
+            {
+                long diff = i.getLongPosition( d ) - c[d];
+                diffSum += diff * diff;
+
+            }
+
+            if ( ( diffSum < r * r ) ) {
+                if ((i.getLongPosition(0) - c[0] < divisionLine)) {
+                    i.get().setInteger(START_LABEL);
+                    ref.get().setInteger( FILL_LABEL );
+                } else if (i.getLongPosition(0) - c[0] > divisionLine) {
+                    i.get().setInteger( START_LABEL );
+                    ref.get().setInteger( START_LABEL );
+                }
+            }
+
+        }
+
+        FloodFill.fill( img, new Point( c ), new DiamondShape( 1 ), fillPolicyFactory );
+
+        for ( Cursor< T > imgCursor = img.cursor(), refCursor = refImg.cursor(); imgCursor.hasNext(); )
+        {
+            Assert.assertEquals( refCursor.next(), imgCursor.next() );
+        }
+
+
+    }
+
+    @Test
+    public void runTests()
+    {
+        for ( int nDim : N_DIMS )
+        {
+            runTest(
+                    nDim,
+                    SIZE_OF_EACH_DIM,
+                    new ArrayImgFactory<LongType>(),
+                    new GenericTypeFillPolicy.Factory<LongType>( new LongType( FILL_LABEL ) ),
+                    new LongType() );
+        }
+    }
+
+}


### PR DESCRIPTION
Implemented Flood Fill for RandomAccessible:
Starting at seed point within randomAccessible, the current pixel gets filled with newLabel. Neighboring pixels, defined by shape, get added to the "queue" if they are part of the same connected component and have not been visited yet, according to fillPolicy.
Implemented FillPolicy for the most simple case of net.imglib2.type.Type in GenericTypeFillPolicy, including factory.
Includes unit test.