### PR TITLE
Iterative n-dimensional floodfill for arbitrary neighborhoods

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,9 +1,9 @@
 Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
 John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
-Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
-Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
-Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov, Curtis Rueden,
-Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>6.0.0</version>
+		<version>7.1.0</version>
 		<relativePath />
 	</parent>
 
 	<artifactId>imglib2-algorithm</artifactId>
-	<version>0.4.1-SNAPSHOT</version>
+	<version>0.5.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Algorithms</name>
 	<description>Useful image processing algorithms.</description>
@@ -28,7 +28,6 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>2.8.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -75,16 +74,6 @@
 						</manifest>
 					</archive>
 				</configuration>
-			</plugin>
-			<!-- Do not enforce fail on SNAPSHOT dependencies -->
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>enforce-rules</id>
-						<phase>none</phase>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
+			<version>2.8.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -48,6 +49,11 @@
 		<dependency>
 			<groupId>gov.nist.math</groupId>
 			<artifactId>jama</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.trove4j</groupId>
+			<artifactId>trove4j</artifactId>
+			<version>3.0.3</version>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -70,6 +76,17 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<!-- Do not enforce fail on SNAPSHOT dependencies -->
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-rules</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/src/main/java/net/imglib2/algorithm/fill/ComparableComparator.java
+++ b/src/main/java/net/imglib2/algorithm/fill/ComparableComparator.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+ * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+ * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+ * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+ * All rights reserved.       
+ *                            
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *                            
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *                            
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *                            
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.util.Pair;
+
+import java.util.Comparator;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ *
+ *
+ * Default implementation of {@link Comparable} for the use in {@link FloodFill} when source and target are both
+ * {@link net.imglib2.RandomAccessible<Comparable>}
+ *
+ */
+public class ComparableComparator< T extends Comparable< T >, U extends Comparable< U >  >
+        implements Comparator<Pair< T, U > > {
+
+    @Override
+    public int compare( final Pair< T, U > p1, final Pair< T, U > p2) {
+        int comp1 = p1.getA().compareTo( p2.getA() );
+        int comp2 = p1.getB().compareTo( p2.getB() );
+        return  comp1 == 0 ?
+                ( comp2 == 0 ? 1 : 0 )
+                : comp1;
+    }
+}

--- a/src/main/java/net/imglib2/algorithm/fill/Filter.java
+++ b/src/main/java/net/imglib2/algorithm/fill/Filter.java
@@ -37,6 +37,7 @@ package net.imglib2.algorithm.fill;
 
 /**
  * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  *
  *
  * Interface for comparing {@link T} t and {@link U} u and accepting them as equivalent in a

--- a/src/main/java/net/imglib2/algorithm/fill/Filter.java
+++ b/src/main/java/net/imglib2/algorithm/fill/Filter.java
@@ -8,18 +8,18 @@
  * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
  * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
  * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
- * All rights reserved.       
- *                            
+ * All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- *                            
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- *                            
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *                            
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -35,27 +35,18 @@
 
 package net.imglib2.algorithm.fill;
 
-import net.imglib2.util.Pair;
-
-import java.util.Comparator;
-
 /**
  * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
  *
  *
- * Default implementation of {@link Comparable} for the use in {@link FloodFill} when source and target are both
- * {@link net.imglib2.RandomAccessible<Comparable>}
+ * Interface for comparing {@link T} t and {@link U} u and accepting them as equivalent in a
+ * sense specified by implementation thereof.
  *
+ * @param <T>
+ * @param <U>
  */
-public class ComparableComparator< T extends Comparable< T >, U extends Comparable< U >  >
-        implements Comparator<Pair< T, U > > {
+public interface Filter< T, U > {
 
-    @Override
-    public int compare( final Pair< T, U > p1, final Pair< T, U > p2) {
-        int comp1 = p1.getA().compareTo( p2.getA() );
-        int comp2 = p1.getB().compareTo( p2.getB() );
-        return  comp1 == 0 ?
-                ( comp2 == 0 ? 1 : 0 )
-                : comp1;
-    }
+    boolean accept( T t, U u );
+
 }

--- a/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
@@ -1,0 +1,207 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+ * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+ * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+ * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+ * All rights reserved.       
+ *                            
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *                            
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *                            
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *                            
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.imglib2.algorithm.fill;
+
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TLongArrayList;
+import net.imglib2.Cursor;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.type.Type;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import net.imglib2.view.Views;
+
+import java.util.Comparator;
+
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
+ * Iterative n-dimensional flood fill for arbitrary neighborhoods.
+ */
+public class FloodFill {
+
+    // int or long? current TLongList cannot store than Integer.MAX_VALUE
+    private static final int CLEANUP_THRESHOLD = (int)1e5;
+
+
+    /**
+     * Iterative n-dimensional flood fill for arbitrary neighborhoods: Starting at seed location, write fillLabel
+     * into target at current location and continue for each pixel in neighborhood defined by shape if neighborhood
+     * pixel is in the same connected component and fillLabel has not been written into that location yet (comparator
+     * evaluates to 0).
+     *
+     * Convenience call to {@link FloodFill#fill(RandomAccessible, RandomAccessible, Localizable, Comparable, Type, Shape)}.
+     * seedLabel is extracted from source at seed location.
+     *
+     * @param source input
+     * @param target {@link RandomAccessible} to be written into. May be the same as input.
+     * @param seed Start flood fill at this location.
+     * @param fillLabel Immutable. Value to be written into valid flood fill locations.
+     * @param <T> T implements {@link Type<U>} and {@link Comparable<T>}.
+     * @param <U> U implements {@link Type<U>} and {@link Comparable<U>}.
+     */
+    public static < T extends Type< T > & Comparable< T >, U extends Type< U > & Comparable< U > > void fill(
+            final RandomAccessible< T > source,
+            final RandomAccessible< U > target,
+            final Localizable seed,
+            final U fillLabel,
+            final Shape shape
+    )
+    {
+        RandomAccess<T> access = source.randomAccess();
+        access.setPosition( seed );
+        fill( source, target, seed, access.get().copy(), fillLabel, shape );
+    }
+
+
+    /**
+     * Iterative n-dimensional flood fill for arbitrary neighborhoods: Starting at seed location, write fillLabel
+     * into target at current location and continue for each pixel in neighborhood defined by shape if neighborhood
+     * pixel is in the same connected component and fillLabel has not been written into that location yet (comparator
+     * evaluates to 0).
+     *
+     * Convenience call to {@link FloodFill#fill(RandomAccessible, RandomAccessible, Localizable, Object, Object, Shape, Comparator, Writer)}
+     * with {@link ComparableComparator} as comparator and {@link TypeWriter} as writer.
+     *
+     * @param source input
+     * @param target {@link RandomAccessible} to be written into. May be the same as input.
+     * @param seed Start flood fill at this location.
+     * @param seedLabel Immutable. Reference value of input at seed location.
+     * @param fillLabel Immutable. Value to be written into valid flood fill locations.
+     * @param <T> T implements {@link Comparable<T>}.
+     * @param <U> U implements {@link Type<U>} and {@link Comparable<U>}.
+     */
+    public static < T extends Comparable< T >, U extends Type< U > & Comparable< U > > void fill(
+            final RandomAccessible< T > source,
+            final RandomAccessible< U > target,
+            final Localizable seed,
+            final T seedLabel,
+            final U fillLabel,
+            final Shape shape
+    )
+    {
+        fill( source, target, seed, seedLabel, fillLabel, shape, new ComparableComparator<T, U>(), new TypeWriter<U>() );
+    }
+
+
+    /**
+     *
+     * Iterative n-dimensional flood fill for arbitrary neighborhoods: Starting at seed location, write fillLabel
+     * into target at current location and continue for each pixel in neighborhood defined by shape if neighborhood
+     * pixel is in the same connected component and fillLabel has not been written into that location yet (comparator
+     * evaluates to 0).
+     *
+     * @param source input
+     * @param target {@link RandomAccessible} to be written into. May be the same as input.
+     * @param seed Start flood fill at this location.
+     * @param seedLabel Immutable. Reference value of input at seed location.
+     * @param fillLabel Immutable. Value to be written into valid flood fill locations.
+     * @param shape Defines neighborhood that is considered for connected components, e.g. {@link net.imglib2.algorithm.neighborhood.DiamondShape}
+     * @param comparator Returns 0 if pixel has not been visited yet and should be written into. Returns non-zero if target pixel has been visited
+     *                   or source pixel is not part of the same connected component. In the most trivial case, comparator will return 0
+     *                   if and only if source at the current location is equal to seedLabel and target at the current location is different
+     *                   from fillLabel, cf {@link ComparableComparator}.
+     * @param writer Defines how fillLabel is written into target at current location.
+     * @param <T> No restrictions on T. Appropriate comparator is the only requirement.
+     * @param <U> No restrictions on U. Appropriate comparator and writer is the only requirement.
+     */
+    public static < T, U > void fill(
+            final RandomAccessible< T > source,
+            final RandomAccessible< U > target,
+            final Localizable seed,
+            final T seedLabel,
+            final U fillLabel,
+            final Shape shape,
+            final Comparator< Pair< T, U > > comparator,
+            final Writer< U > writer )
+    {
+        final int n = source.numDimensions();
+
+        final ValuePair< T, U > reference = new ValuePair< T, U >( seedLabel, fillLabel );
+
+        RandomAccessible< Pair< T, U > > paired = Views.pair(source, target);
+
+        final TLongList[] coordinates = new TLongList[ n ];
+        for ( int d = 0; d < n; ++d )
+        {
+            coordinates[ d ] = new TLongArrayList();
+            coordinates[ d ].add( seed.getLongPosition( d ) );
+        }
+
+        final RandomAccessible<Neighborhood< Pair< T, U> > > neighborhood = shape.neighborhoodsRandomAccessible( paired );
+        final RandomAccess<Neighborhood< Pair<T, U > > > neighborhoodAccess = neighborhood.randomAccess();
+
+        final RandomAccess< U > targetAccess = target.randomAccess();
+        targetAccess.setPosition( seed );
+        writer.write( fillLabel, targetAccess.get() );
+
+        for ( int i = 0; i < coordinates[ 0 ].size(); ++i )
+        {
+            for ( int d = 0; d < n; ++d )
+                neighborhoodAccess.setPosition( coordinates[d].get(i), d);
+
+            final Cursor< Pair< T, U > > neighborhoodCursor = neighborhoodAccess.get().cursor();
+
+            while ( neighborhoodCursor.hasNext() )
+            {
+                Pair< T, U > p = neighborhoodCursor.next();
+                if ( comparator.compare( p, reference ) == 0 )
+                {
+                    writer.write( fillLabel, p.getB() );
+                    for ( int d = 0; d < n; ++d )
+                        coordinates[ d ].add( neighborhoodCursor.getLongPosition( d ) );
+                }
+            }
+
+            if ( i > CLEANUP_THRESHOLD )
+            {
+                for ( int d = 0; d < coordinates.length; ++d ) {
+                    TLongList c = coordinates[ d ];
+                    coordinates[ d ] = c.subList( i, c.size() );
+                }
+                i = 0;
+            }
+
+        }
+
+    }
+
+}

--- a/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
+++ b/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
@@ -46,7 +46,7 @@ import net.imglib2.type.Type;
  */
 public class TypeWriter< T extends Type< T > > implements Writer< T > {
 
-        @Override
+    @Override
     public void write( final T source, final T target) {
         target.set( source );
     }

--- a/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
+++ b/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
@@ -39,6 +39,7 @@ import net.imglib2.type.Type;
 
 /**
  * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  *
  *
  * Default implementation of {@link Writer} for {@link Type}.

--- a/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
+++ b/src/main/java/net/imglib2/algorithm/fill/TypeWriter.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+ * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+ * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+ * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+ * All rights reserved.       
+ *                            
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *                            
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *                            
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *                            
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.type.Type;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ *
+ *
+ * Default implementation of {@link Writer} for {@link Type}.
+ *
+ */
+public class TypeWriter< T extends Type< T > > implements Writer< T > {
+
+        @Override
+    public void write( final T source, final T target) {
+        target.set( source );
+    }
+
+}

--- a/src/main/java/net/imglib2/algorithm/fill/Writer.java
+++ b/src/main/java/net/imglib2/algorithm/fill/Writer.java
@@ -37,6 +37,7 @@ package net.imglib2.algorithm.fill;
 
 /**
  * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  *
  *
  * Interface for writing from arbitrary source into target (same types).

--- a/src/main/java/net/imglib2/algorithm/fill/Writer.java
+++ b/src/main/java/net/imglib2/algorithm/fill/Writer.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+ * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+ * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+ * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+ * All rights reserved.       
+ *                            
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *                            
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *                            
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *                            
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.imglib2.algorithm.fill;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ *
+ *
+ * Interface for writing from arbitrary source into target (same types).
+ * @param <U>
+ */
+public interface Writer< U > {
+
+    void write( final U source, final U target );
+
+}

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
@@ -73,7 +73,7 @@ public class Spur
 
 		final ImgFactory< T > factory;
 		if ( extendedVal instanceof NativeType )
-			factory = Util.getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
+			factory = Util.< NativeType >getArrayOrCellImgFactory( target, (NativeType) extendedVal );
 		else
 			factory = new ListImgFactory< T >();
 		Img< T > temp = factory.create( targetDims, extendedVal );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
@@ -73,7 +73,7 @@ public class Spur
 
 		final ImgFactory< T > factory;
 		if ( extendedVal instanceof NativeType )
-			factory = ( ImgFactory< T > ) Util.getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
+			factory = Util.< NativeType >getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
 		else
 			factory = new ListImgFactory< T >();
 		Img< T > temp = factory.create( targetDims, extendedVal );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
@@ -87,7 +87,7 @@ public class Thin
 
 		final ImgFactory< T > factory;
 		if ( extendedVal instanceof NativeType )
-			factory = ( ImgFactory< T > ) Util.getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
+			factory = Util.< NativeType >getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
 		else
 			factory = new ListImgFactory< T >();
 		Img< T > temp = factory.create( targetDims, extendedVal );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
@@ -87,7 +87,7 @@ public class Thin
 
 		final ImgFactory< T > factory;
 		if ( extendedVal instanceof NativeType )
-			factory = Util.getArrayOrCellImgFactory( target, ( NativeType ) extendedVal );
+			factory = Util.< NativeType >getArrayOrCellImgFactory( target, ( NativeType ) (Object) extendedVal );
 		else
 			factory = new ListImgFactory< T >();
 		Img< T > temp = factory.create( targetDims, extendedVal );

--- a/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
+++ b/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 /**
  * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  */
 public class FloodFillTest {
 

--- a/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
+++ b/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
@@ -43,6 +43,7 @@ import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.util.Pair;
 import net.imglib2.view.ExtendedRandomAccessibleInterval;
 import net.imglib2.view.Views;
 import org.junit.Assert;
@@ -107,7 +108,15 @@ public class FloodFillTest {
 
         ExtendedRandomAccessibleInterval<T, Img<T>> extendedImg = Views.extendValue(img, fillLabel);
 
-        FloodFill.fill( extendedImg, extendedImg, new Point( c ), fillLabel, new DiamondShape( 1 ) );
+        Filter<Pair<T, T>, Pair<T, T>> filter = new Filter< Pair< T, T >, Pair< T, T > >() {
+            @Override
+            public boolean accept(Pair< T, T > p1, Pair< T, T > p2) {
+                return ( p1.getB().getIntegerLong() != p2.getB().getIntegerLong() ) &&
+                        ( p1.getA().getIntegerLong() == p2.getA().getIntegerLong() );
+            }
+        };
+
+        FloodFill.fill( extendedImg, extendedImg, new Point( c ), fillLabel, new DiamondShape( 1 ), filter );
 
         for ( Cursor< T > imgCursor = img.cursor(), refCursor = refImg.cursor(); imgCursor.hasNext(); )
         {

--- a/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
+++ b/src/test/java/net/imglib2/algorithm/fill/FloodFillTest.java
@@ -1,0 +1,134 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (c) 2009 - 2016, Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Philipp Hanslovsky, Grant Harris, Stefan Helfrich,
+ * Mark Hiner, Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey,
+ * Melissa Linkert, Mark Longair, Brian Northan, Nick Perry, Dimiter Prodanov,
+ * Curtis Rueden, Johannes Schindelin, Jean-Yves Tinevez and Michael Zinsmaier.
+ * All rights reserved.       
+ *                            
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *                            
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *                            
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *                            
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.imglib2.algorithm.fill;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.Views;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Philipp Hanslovsky &lt;hanslovskyp@janelia.hhmi.org&gt;
+ */
+public class FloodFillTest {
+
+    private static final long START_LABEL = 1;
+    private static final long FILL_LABEL = 2;
+    private static final int[] N_DIMS = { 1, 2, 3, 4 };
+    private static final int SIZE_OF_EACH_DIM = 60;
+
+
+    private static < T extends IntegerType < T > > void runTest(
+            int nDim,
+            int sizeOfEachDim,
+            ImgFactory< T > imageFactory,
+            T t )
+    {
+        long[] dim = new long[nDim];
+        long[] c = new long[nDim];
+        long r = sizeOfEachDim / 4;
+        for ( int d = 0; d < nDim; ++d ) {
+            dim[d] = sizeOfEachDim;
+            c[d] = sizeOfEachDim / 3;
+        }
+
+        long divisionLine = r / 3;
+
+        Img<T> img = imageFactory.create(dim, t.copy() );
+        Img<T> refImg = imageFactory.create(dim, t.copy());
+
+        for (Cursor<T> i = img.cursor(), ref = refImg.cursor(); i.hasNext(); )
+        {
+            i.fwd();
+            ref.fwd();
+            long diffSum = 0;
+            for ( int d = 0; d < nDim; ++d )
+            {
+                long diff = i.getLongPosition( d ) - c[d];
+                diffSum += diff * diff;
+
+            }
+
+            if ( ( diffSum < r * r ) ) {
+                if ((i.getLongPosition(0) - c[0] < divisionLine)) {
+                    i.get().setInteger(START_LABEL);
+                    ref.get().setInteger( FILL_LABEL );
+                } else if (i.getLongPosition(0) - c[0] > divisionLine) {
+                    i.get().setInteger( START_LABEL );
+                    ref.get().setInteger( START_LABEL );
+                }
+            }
+
+        }
+
+        T fillLabel = t.createVariable();
+        fillLabel.setInteger( FILL_LABEL );
+
+        ExtendedRandomAccessibleInterval<T, Img<T>> extendedImg = Views.extendValue(img, fillLabel);
+
+        FloodFill.fill( extendedImg, extendedImg, new Point( c ), fillLabel, new DiamondShape( 1 ) );
+
+        for ( Cursor< T > imgCursor = img.cursor(), refCursor = refImg.cursor(); imgCursor.hasNext(); )
+        {
+            Assert.assertEquals( refCursor.next(), imgCursor.next() );
+        }
+
+
+    }
+
+    @Test
+    public void runTests()
+    {
+        for ( int nDim : N_DIMS )
+        {
+            runTest(
+                    nDim,
+                    SIZE_OF_EACH_DIM,
+                    new ArrayImgFactory<LongType>(),
+                    new LongType()
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
Flood fill based on user defined connectivity check and only if pixel
has not been visited yet (Comparator). User defines how to write into
target using Writer and neighborhood using Shape. That way, we do not
have any  requirement on source and target types. Added convenience
methods for input type extending Comparable (and Type) and output
extending Comparable and Type.

Added default implementations for Comparator and Writer.

Update of #21 according to [comments by @axtimwalde](https://github.com/imglib/imglib2-algorithm/pull/21#issuecomment-213164965).
Requires latest checkout of imglib2 master.