### PR TITLE
getStructuringElementBoundingBox() for Shapes

### DIFF
--- a/src/main/java/net/imglib2/algorithm/neighborhood/CenteredRectangleShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/CenteredRectangleShape.java
@@ -40,6 +40,7 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleShape.NeighborhoodsAccessible;
 import net.imglib2.algorithm.neighborhood.RectangleShape.NeighborhoodsIterableInterval;
+import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 
 /**
@@ -151,5 +152,18 @@ public class CenteredRectangleShape implements Shape
 			max[ d ] = span[ d ];
 		}
 		return new FinalInterval( min, max );
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] a = new long[numDimensions];
+		final long[] b = new long[numDimensions];
+
+		for (int i = 0; i < numDimensions; ++i) {
+			a[i] = span[i] * -1;
+			b[i] = span[i];
+		}
+
+		return Intervals.union(new FinalInterval(a, a), new FinalInterval(b, b));
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/DiamondShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/DiamondShape.java
@@ -33,11 +33,13 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
@@ -202,5 +204,16 @@ public class DiamondShape implements Shape
 			return source.numDimensions();
 		}
 
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] min = new long[numDimensions];
+		Arrays.fill(min, -getRadius());
+
+		final long[] max = new long[numDimensions];
+		Arrays.fill(max, getRadius());
+
+		return new FinalInterval(min, max);
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/DiamondTipsShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/DiamondTipsShape.java
@@ -33,11 +33,13 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
@@ -204,5 +206,16 @@ public class DiamondTipsShape implements Shape
 			return source.numDimensions();
 		}
 
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] min = new long[numDimensions];
+		Arrays.fill(min, -getRadius());
+
+		final long[] max = new long[numDimensions];
+		Arrays.fill(max, getRadius());
+
+		return new FinalInterval(min, max);
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/HorizontalLineShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/HorizontalLineShape.java
@@ -38,12 +38,14 @@ import java.util.Iterator;
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.Intervals;
 
 /**
  * A {@link Shape} representing finite, centered, symmetric lines, that are
@@ -243,4 +245,16 @@ public class HorizontalLineShape implements Shape
 		}
 
 	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] a = new long[numDimensions];
+		final long[] b = new long[numDimensions];
+
+		a[dim] = -span;
+		b[dim] = span;
+
+		return Intervals.union(new FinalInterval(a, a), new FinalInterval(b, b));
+	}
+
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/HyperSphereShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/HyperSphereShape.java
@@ -34,11 +34,13 @@
 
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
@@ -186,5 +188,16 @@ public class HyperSphereShape implements Shape
 		{
 			return new HyperSphereNeighborhoodRandomAccess< T >( source, radius, factory, interval );
 		}
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] min = new long[numDimensions];
+		Arrays.fill(min, -getRadius());
+
+		final long[] max = new long[numDimensions];
+		Arrays.fill(max, getRadius());
+
+		return new FinalInterval(min, max);
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/PairOfPointsShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/PairOfPointsShape.java
@@ -33,17 +33,20 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 
 /**
@@ -199,6 +202,15 @@ public class PairOfPointsShape implements Shape
 		{
 			return source.numDimensions();
 		}
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] zeroMin = new long[numDimensions];
+		Arrays.fill(zeroMin, 0);
+
+		return Intervals.union(new FinalInterval(zeroMin, zeroMin),
+			new FinalInterval(offset, offset));
 	}
 
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/PeriodicLineShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/PeriodicLineShape.java
@@ -38,12 +38,14 @@ import java.util.Iterator;
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 
 /**
@@ -241,6 +243,19 @@ public class PeriodicLineShape implements Shape
 		{
 			return source.numDimensions();
 		}
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox(final int numDimensions) {
+		final long[] a = new long[numDimensions];
+		final long[] b = new long[numDimensions];
+
+		for (int i = 0; i < numDimensions; ++i) {
+			a[i] = increments[i] * -getSpan();
+			b[i] = increments[i] * getSpan();
+		}
+
+		return Intervals.union(new FinalInterval(a, a), new FinalInterval(b, b));
 	}
 
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/RectangleShape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/RectangleShape.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.AbstractEuclideanSpace;
@@ -223,5 +224,17 @@ public class RectangleShape implements Shape
 		{
 			return new RectangleNeighborhoodRandomAccess< T >( source, span, factory, interval );
 		}
+	}
+
+	@Override
+	public Interval getStructuringElementBoundingBox( final int numDimensions )
+	{
+		final long[] min = new long[ numDimensions ];
+		Arrays.fill( min, -getSpan() );
+
+		final long[] max = new long[ numDimensions ];
+		Arrays.fill( max, getSpan() );
+
+		return new FinalInterval( min, max );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
@@ -35,6 +35,7 @@
 package net.imglib2.algorithm.neighborhood;
 
 import net.imglib2.Cursor;
+import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
@@ -48,6 +49,14 @@ import net.imglib2.Sampler;
  */
 public interface Shape
 {
+	/**
+	 * TODO Documentation
+	 * 
+	 * @param numDimensions
+	 * @return
+	 */
+	public Interval getStructuringElementBoundingBox( final int numDimensions );
+
 	/**
 	 * Get an {@link IterableInterval} that contains all {@link Neighborhood
 	 * Neighborhoods} of the source image.

--- a/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
@@ -34,13 +34,17 @@
 
 package net.imglib2.algorithm.neighborhood;
 
+import java.util.stream.LongStream;
+
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Sampler;
+import net.imglib2.util.ConstantUtils;
 
 /**
  * A factory for Accessibles on {@link Neighborhood Neighborhoods}.
@@ -69,7 +73,25 @@ public interface Shape
 	 * @return an {@link Interval} that describes the bounding box of a
 	 *         {@link Shape}
 	 */
-	public Interval getStructuringElementBoundingBox(final int numDimensions);
+	public default Interval getStructuringElementBoundingBox( final int numDimensions )
+	{
+		final RandomAccessible< Object > accessible = ConstantUtils.constantRandomAccessible( null, numDimensions );
+		final RandomAccess< Neighborhood< Object > > access = neighborhoodsRandomAccessible( accessible ).randomAccess();
+		access.setPosition( new long[ numDimensions ] );
+		final long[] min = LongStream.generate( () -> Long.MAX_VALUE ).limit( numDimensions ).toArray();
+		final long[] max = LongStream.generate( () -> Long.MIN_VALUE ).limit( numDimensions ).toArray();
+		for ( final Cursor< Object > cursor = access.get().localizingCursor(); cursor.hasNext(); )
+		{
+			cursor.fwd();
+			for ( int d = 0; d < numDimensions; ++d )
+			{
+				final long pos = cursor.getLongPosition( d );
+				min[ d ] = Math.min( pos, min[ d ] );
+				max[ d ] = Math.max( pos, max[ d ] );
+			}
+		}
+		return new FinalInterval( min, max );
+	}
 
 	/**
 	 * Get an {@link IterableInterval} that contains all {@link Neighborhood

--- a/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
+++ b/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java
@@ -49,13 +49,27 @@ import net.imglib2.Sampler;
  */
 public interface Shape
 {
+
 	/**
-	 * TODO Documentation
+	 * Get the bounding box for a {@link Shape} with {@code numDimensions}
+	 * dimensions.
+	 * <p>
+	 * Providing {@code numDimensions} is required since the input from which
+	 * {@link Neighborhood neighborhoods} are generated is not known yet. The
+	 * bounding box is described by an {@link Interval} with the center of the
+	 * bounding box located at zero.
+	 * </p>
+	 * <p>
+	 * The values of this bounding box should only be used to determine the extent
+	 * of the {@link Shape}, ignoring the absolute {@link Interval#min(int) min}
+	 * and {@link Interval#max(int) max} values.
+	 * </p>
 	 * 
-	 * @param numDimensions
-	 * @return
+	 * @param numDimensions dimensions of the {@link Shape}
+	 * @return an {@link Interval} that describes the bounding box of a
+	 *         {@link Shape}
 	 */
-	public Interval getStructuringElementBoundingBox( final int numDimensions );
+	public Interval getStructuringElementBoundingBox(final int numDimensions);
 
 	/**
 	 * Get an {@link IterableInterval} that contains all {@link Neighborhood

--- a/src/test/java/net/imglib2/algorithm/neighborhood/CenteredRectangleShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/CenteredRectangleShapeTest.java
@@ -33,8 +33,15 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class CenteredRectangleShapeTest extends AbstractShapeTest
 {
@@ -56,5 +63,13 @@ public class CenteredRectangleShapeTest extends AbstractShapeTest
 		}
 		return true;
 
+	}
+
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -2,
+			-3, -1 }, new long[] { 2, 3, 1 })));
 	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/DiamondShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/DiamondShapeTest.java
@@ -33,8 +33,15 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.DiamondShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class DiamondShapeTest extends AbstractShapeTest
 {
@@ -58,4 +65,11 @@ public class DiamondShapeTest extends AbstractShapeTest
 		return cityblock <= RADIUS;
 	}
 
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -3,
+			-3, -3 }, new long[] { 3, 3, 3 })));
+	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/DiamondTipsShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/DiamondTipsShapeTest.java
@@ -33,8 +33,15 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.DiamondTipsShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class DiamondTipsShapeTest extends AbstractShapeTest
 {
@@ -71,5 +78,13 @@ public class DiamondTipsShapeTest extends AbstractShapeTest
 			}
 		}
 		return false;
+	}
+
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -3,
+			-3, -3 }, new long[] { 3, 3, 3 })));
 	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/HorizontalLineShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/HorizontalLineShapeTest.java
@@ -33,8 +33,15 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class HorizontalLineShapeTest extends AbstractShapeTest
 {
@@ -68,4 +75,11 @@ public class HorizontalLineShapeTest extends AbstractShapeTest
 		return true;
 	}
 
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { 0,
+			-3, 0 }, new long[] { 0, 3, 0 })));
+	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/HypersphereShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/HypersphereShapeTest.java
@@ -33,6 +33,14 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
+
 /**
  * Test {@link HyperSphereShape}.
  *
@@ -59,4 +67,11 @@ public class HypersphereShapeTest extends AbstractShapeTest
 		return squlen <= RADIUS * RADIUS;
 	}
 
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -3,
+			-3, -3 }, new long[] { 3, 3, 3 })));
+	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/PairOfPointsShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/PairOfPointsShapeTest.java
@@ -33,10 +33,17 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.*;
+
 import java.util.Arrays;
 
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.PairOfPointsShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class PairOfPointsShapeTest extends AbstractShapeTest
 {
@@ -61,4 +68,11 @@ public class PairOfPointsShapeTest extends AbstractShapeTest
 		return true;
 	}
 
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(
+			OFFSET.length);
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { 0,
+			0, 0 }, OFFSET)));
+	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/PeriodicLineShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/PeriodicLineShapeTest.java
@@ -33,8 +33,15 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.algorithm.neighborhood.PeriodicLineShape;
 import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
 
 public class PeriodicLineShapeTest extends AbstractShapeTest
 {
@@ -74,6 +81,14 @@ public class PeriodicLineShapeTest extends AbstractShapeTest
 			}
 		}
 		return true;
+	}
+
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(
+			INCREMENTS.length);
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -4,
+			-2, 0 }, new long[] { 4, 2, 0 })));
 	}
 
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/RectangleShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/RectangleShapeTest.java
@@ -33,6 +33,14 @@
  */
 package net.imglib2.algorithm.neighborhood;
 
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.util.Intervals;
+
+import org.junit.Test;
+
 /**
  * Test {@link RectangleShape}.
  * 
@@ -60,4 +68,11 @@ public class RectangleShapeTest extends AbstractShapeTest
 		return true;
 	}
 
+	@Test
+	public void testStructuringElementBoundingBox() {
+		Interval boundingBox = shape.getStructuringElementBoundingBox(img
+			.numDimensions());
+		assertTrue(Intervals.equals(boundingBox, new FinalInterval(new long[] { -3,
+			-3, -3 }, new long[] { 3, 3, 3 })));
+	}
 }

--- a/src/test/java/net/imglib2/algorithm/neighborhood/ShapeTest.java
+++ b/src/test/java/net/imglib2/algorithm/neighborhood/ShapeTest.java
@@ -1,0 +1,80 @@
+package net.imglib2.algorithm.neighborhood;
+
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.RectangleShape.NeighborhoodsAccessible;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.util.Intervals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test default implementations of {@link Shape}.
+ * 
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+public class ShapeTest
+{
+
+	protected Shape shape;
+
+	protected ArrayImg< UnsignedShortType, ShortArray > img;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		final long[] dims = new long[] { 10, 10, 10 };
+		this.img = ArrayImgs.unsignedShorts( dims );
+		this.shape = new Shape()
+		{
+
+			@Override
+			public < T > IterableInterval< Neighborhood< T > > neighborhoods( RandomAccessibleInterval< T > source )
+			{
+				// Not used by default getStructuringElementBoundingBox()
+				return null;
+			}
+
+			@Override
+			public < T > RandomAccessible< Neighborhood< T > > neighborhoodsRandomAccessible( RandomAccessible< T > source )
+			{
+				final RectangleNeighborhoodFactory< T > f = RectangleNeighborhoodUnsafe.< T >factory();
+				final Interval spanInterval = new FinalInterval( new long[] { -3, -3, -3 }, new long[] { 3, 3, 3 } );
+				return new NeighborhoodsAccessible<>( source, spanInterval, f );
+			}
+
+			@Override
+			public < T > IterableInterval< Neighborhood< T > > neighborhoodsSafe( RandomAccessibleInterval< T > source )
+			{
+				// Not used by default getStructuringElementBoundingBox()
+				return null;
+			}
+
+			@Override
+			public < T > RandomAccessible< Neighborhood< T > > neighborhoodsRandomAccessibleSafe( RandomAccessible< T > source )
+			{
+				// Not used by default getStructuringElementBoundingBox()
+				return null;
+			}
+
+		};
+	}
+
+	@Test
+	public void testStructuringElementBoundingBox()
+	{
+		Interval boundingBox = shape.getStructuringElementBoundingBox(
+				img.numDimensions() );
+		assertTrue( Intervals.equals( boundingBox, new FinalInterval(
+				new long[] { -3, -3, -3 }, new long[] { 3, 3, 3 } ) ) );
+	}
+}


### PR DESCRIPTION
Adds `Shape.getStructuringElementBoundingBox()` and default implementations to the subclasses.

This PR addresses the remaining point of a generic bounding box of #5.  
