### PR TITLE
DogDetection usability improvements

### DIFF
--- a/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
@@ -82,10 +82,10 @@ public class DifferenceOfGaussian
 	 * @param service
 	 *            service providing threads for multi-threading
 	 */
-	public static < T extends NumericType< T > & NativeType< T > > void DoG(
+	public static < I extends NumericType< I >, T extends NumericType< T > & NativeType< T > > void DoG(
 			final double[] sigmaSmaller,
 			final double[] sigmaLarger,
-			final RandomAccessible< T > input,
+			final RandomAccessible< I > input,
 			final RandomAccessibleInterval< T > dog,
 			final ExecutorService service )
 	{
@@ -117,10 +117,10 @@ public class DifferenceOfGaussian
 	 * @param service
 	 *            how many threads to use for the computation.
 	 */
-	public static < T extends NumericType< T > & NativeType< T > > void DoG(
+	public static < I extends NumericType< I >, T extends NumericType< T > & NativeType< T > > void DoG(
 			final double[] sigmaSmaller,
 			final double[] sigmaLarger,
-			final RandomAccessible< T > input,
+			final RandomAccessible< I > input,
 			final RandomAccessible< T > tmp,
 			final RandomAccessibleInterval< T > dog,
 			final ExecutorService service )

--- a/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
@@ -62,16 +62,16 @@ public class DifferenceOfGaussian
 {
 	/**
 	 * Compute the difference of Gaussian for the input. Input convolved with
-	 * Gaussian of sigma1 is subtracted from input convolved with Gaussian of
-	 * sigma2 (where sigma2 > sigma1).
-	 * 
+	 * Gaussian of sigmaSmaller is subtracted from input convolved with Gaussian
+	 * of sigmaLarger (where sigmaLarger > sigmaSmaller).
+	 *
 	 * <p>
 	 * Creates an appropriate temporary image and calls
 	 * {@link #DoG(double[], double[], RandomAccessible, RandomAccessible, RandomAccessibleInterval, int)}.
-	 * 
-	 * @param sigma1
+	 *
+	 * @param sigmaSmaller
 	 *            stddev (in every dimension) of smaller Gaussian.
-	 * @param sigma2
+	 * @param sigmaLarger
 	 *            stddev (in every dimension) of larger Gaussian.
 	 * @param input
 	 *            the input image extended to infinity (or at least covering the
@@ -82,23 +82,28 @@ public class DifferenceOfGaussian
 	 * @param service
 	 *            service providing threads for multi-threading
 	 */
-	public static < T extends NumericType< T > & NativeType< T > > void DoG( final double[] sigma1, final double[] sigma2, final RandomAccessible< T > input, final RandomAccessibleInterval< T > dog, final ExecutorService service )
+	public static < T extends NumericType< T > & NativeType< T > > void DoG(
+			final double[] sigmaSmaller,
+			final double[] sigmaLarger,
+			final RandomAccessible< T > input,
+			final RandomAccessibleInterval< T > dog,
+			final ExecutorService service )
 	{
 		final T type = Util.getTypeFromInterval( dog );
 		final Img< T > g1 = Util.getArrayOrCellImgFactory( dog, type ).create( dog, type );
 		final long[] translation = new long[ dog.numDimensions() ];
 		dog.min( translation );
-		DoG( sigma1, sigma2, input, Views.translate( g1, translation ), dog, service );
+		DoG( sigmaSmaller, sigmaLarger, input, Views.translate( g1, translation ), dog, service );
 	}
 
 	/**
 	 * Compute the difference of Gaussian for the input. Input convolved with
-	 * Gaussian of sigma1 is subtracted from input convolved with Gaussian of
-	 * sigma2 (where sigma2 > sigma1).
-	 * 
-	 * @param sigma1
+	 * Gaussian of sigmaSmaller is subtracted from input convolved with Gaussian
+	 * of sigmaLarger (where sigmaLarger > sigmaSmaller).
+	 *
+	 * @param sigmaSmaller
 	 *            stddev (in every dimension) of smaller Gaussian.
-	 * @param sigma2
+	 * @param sigmaLarger
 	 *            stddev (in every dimension) of larger Gaussian.
 	 * @param input
 	 *            the input image extended to infinity (or at least covering the
@@ -112,13 +117,19 @@ public class DifferenceOfGaussian
 	 * @param service
 	 *            how many threads to use for the computation.
 	 */
-	public static < T extends NumericType< T > > void DoG( final double[] sigma1, final double[] sigma2, final RandomAccessible< T > input, final RandomAccessible< T > tmp, final RandomAccessibleInterval< T > dog, final ExecutorService service )
+	public static < T extends NumericType< T > & NativeType< T > > void DoG(
+			final double[] sigmaSmaller,
+			final double[] sigmaLarger,
+			final RandomAccessible< T > input,
+			final RandomAccessible< T > tmp,
+			final RandomAccessibleInterval< T > dog,
+			final ExecutorService service )
 	{
 		final IntervalView< T > tmpInterval = Views.interval( tmp, dog );
 		try
 		{
-			Gauss3.gauss( sigma1, input, tmpInterval, service );
-			Gauss3.gauss( sigma2, input, dog, service );
+			Gauss3.gauss( sigmaSmaller, input, tmpInterval, service );
+			Gauss3.gauss( sigmaLarger, input, dog, service );
 		}
 		catch ( final IncompatibleTypeException e )
 		{
@@ -131,7 +142,7 @@ public class DifferenceOfGaussian
 		final int numThreads = Runtime.getRuntime().availableProcessors();
 		final int numTasks = numThreads <= 1 ? 1 : numThreads * 20;
 		final long taskSize = size / numTasks;
-		final ArrayList< Future< Void > > futures = new ArrayList< Future< Void > >();
+		final ArrayList< Future< Void > > futures = new ArrayList<>();
 		for ( int taskNum = 0; taskNum < numTasks; ++taskNum )
 		{
 			final long fromIndex = taskNum * taskSize;

--- a/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
@@ -59,7 +59,15 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 {
 	public static enum ExtremaType
 	{
-		MINIMA, MAXIMA
+		/**
+		 * Bright blobs on dark background.
+		 */
+		MINIMA,
+
+		/**
+		 * Dark blobs on bright background.
+		 */
+		MAXIMA
 	}
 
 	/**

--- a/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
@@ -70,24 +70,24 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 
 	public < I extends RandomAccessibleInterval< T > & LinearSpace< ? > > DogDetection(
 			final I input,
-			final double sigma1,
-			final double sigma2,
+			final double sigmaSmaller,
+			final double sigmaLarger,
 			final ExtremaType extremaType,
 			final double minPeakValue )
 	{
-		this( Views.extendMirrorSingle( input ), input, getcalib( input ), sigma1, sigma2, extremaType, minPeakValue, true );
+		this( Views.extendMirrorSingle( input ), input, getcalib( input ), sigmaSmaller, sigmaLarger, extremaType, minPeakValue, true );
 	}
 
 	public DogDetection(
 			final RandomAccessibleInterval< T > input,
 			final double[] calibration,
-			final double sigma1,
-			final double sigma2,
+			final double sigmaSmaller,
+			final double sigmaLarger,
 			final ExtremaType extremaType,
 			final double minPeakValue,
 			final boolean normalizeMinPeakValue )
 	{
-		this( Views.extendMirrorSingle( input ), input, calibration, sigma1, sigma2, extremaType, minPeakValue, true );
+		this( Views.extendMirrorSingle( input ), input, calibration, sigmaSmaller, sigmaLarger, extremaType, minPeakValue, true );
 	}
 
 	/**
@@ -101,9 +101,9 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 	 * @param calibration
 	 *            The calibration, i.e., the voxel sizes in some unit for the
 	 *            input image.
-	 * @param sigma1
+	 * @param sigmaSmaller
 	 *            sigma for the smaller scale in the same units as calibration.
-	 * @param sigma2
+	 * @param sigmaLarger
 	 *            sigma for the larger scale in the same units as calibration.
 	 * @param extremaType
 	 *            which type of extrema (minima, maxima) to detect. Note that
@@ -118,7 +118,7 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 	 *            Whether the peak value should be normalized. The
 	 *            Difference-of-Gaussian is an approximation of the
 	 *            scale-normalized Laplacian-of-Gaussian, with a factor of
-	 *            <em>f = sigma1 / (sigma2 - sigma1)</em>. If
+	 *            <em>f = sigmaSmaller / (sigmaLarger - sigmaSmaller)</em>. If
 	 *            {@code normalizeMinPeakValue=true}, the {@code minPeakValue}
 	 *            will be divided by <em>f</em> (which is equivalent to scaling
 	 *            the DoG by <em>f</em>).
@@ -127,16 +127,16 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 			final RandomAccessible< T > input,
 			final Interval interval,
 			final double[] calibration,
-			final double sigma1,
-			final double sigma2,
+			final double sigmaSmaller,
+			final double sigmaLarger,
 			final ExtremaType extremaType,
 			final double minPeakValue,
 			final boolean normalizeMinPeakValue )
 	{
 		this.input = input;
 		this.interval = interval;
-		this.sigma1 = sigma1;
-		this.sigma2 = sigma2;
+		this.sigmaSmaller = sigmaSmaller;
+		this.sigmaLarger = sigmaLarger;
 		this.pixelSize = calibration;
 		this.imageSigma = 0.5;
 		this.minf = 2;
@@ -165,13 +165,13 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 		interval.min( translation );
 		dogImg = Views.translate( dogImg, translation );
 
-		final double[][] sigmas = DifferenceOfGaussian.computeSigmas( imageSigma, minf, pixelSize, sigma1, sigma2 );
+		final double[][] sigmas = DifferenceOfGaussian.computeSigmas( imageSigma, minf, pixelSize, sigmaSmaller, sigmaLarger );
 		DifferenceOfGaussian.DoG( sigmas[ 0 ], sigmas[ 1 ], input, dogImg, service );
 		final T val = type.createVariable();
 		final double minValueT = type.getMinValue();
 		final double maxValueT = type.getMaxValue();
 		final LocalNeighborhoodCheck< Point, T > localNeighborhoodCheck;
-		final double normalization = normalizeMinPeakValue ? ( sigma2 / sigma1 - 1.0 ) : 1.0;
+		final double normalization = normalizeMinPeakValue ? ( sigmaLarger / sigmaSmaller - 1.0 ) : 1.0;
 		switch ( extremaType )
 		{
 		case MINIMA:
@@ -212,9 +212,9 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 
 	protected final Interval interval;
 
-	protected final double sigma1;
+	protected final double sigmaSmaller;
 
-	protected final double sigma2;
+	protected final double sigmaLarger;
 
 	protected final double[] pixelSize;
 

--- a/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
@@ -176,12 +176,12 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 		{
 		case MINIMA:
 			val.setReal( Math.max( Math.min( -minPeakValue * normalization, maxValueT ), minValueT ) );
-			localNeighborhoodCheck = new LocalExtrema.MinimumCheck< T >( val );
+			localNeighborhoodCheck = new LocalExtrema.MinimumCheck<>( val );
 			break;
 		case MAXIMA:
 		default:
 			val.setReal( Math.max( Math.min( minPeakValue * normalization, maxValueT ), minValueT ) );
-			localNeighborhoodCheck = new LocalExtrema.MaximumCheck< T >( val );
+			localNeighborhoodCheck = new LocalExtrema.MaximumCheck<>( val );
 		}
 		final ArrayList< Point > peaks = LocalExtrema.findLocalExtrema( dogImg, localNeighborhoodCheck, service );
 		if ( !keepDoGImg )
@@ -198,7 +198,7 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 		final boolean savedKeepDoGImg = keepDoGImg;
 		keepDoGImg = true;
 		final ArrayList< Point > peaks = getPeaks();
-		final SubpixelLocalization< Point, T > spl = new SubpixelLocalization< Point, T >( dogImg.numDimensions() );
+		final SubpixelLocalization< Point, T > spl = new SubpixelLocalization<>( dogImg.numDimensions() );
 		spl.setAllowMaximaTolerance( true );
 		spl.setMaxNumMoves( 10 );
 		final ArrayList< RefinedPeak< Point > > refined = spl.process( peaks, dogImg, dogImg );

--- a/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DogDetection.java
@@ -48,6 +48,8 @@ import net.imglib2.algorithm.localextrema.RefinedPeak;
 import net.imglib2.algorithm.localextrema.SubpixelLocalization;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
@@ -100,7 +102,9 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 
 	/**
 	 * Sets up a {@link DogDetection} with the specified parameters (does not do
-	 * any computation yet).
+	 * any computation yet). If the input image is of type {@link DoubleType},
+	 * {@link DoubleType} will be used for computing the Difference-of-Gaussian.
+	 * In all other cases, {@link FloatType} will be used).
 	 *
 	 * @param input
 	 *            the input image.
@@ -141,11 +145,61 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 			final double minPeakValue,
 			final boolean normalizeMinPeakValue )
 	{
+		this( input, interval, calibration, sigmaSmaller, sigmaLarger, extremaType, minPeakValue, normalizeMinPeakValue, new DogComputationType<>( input, interval ).getType() );
+	}
+
+	/**
+	 * Sets up a {@link DogDetection} with the specified parameters (does not do
+	 * any computation yet).
+	 *
+	 * @param input
+	 *            the input image.
+	 * @param interval
+	 *            which interval of the input image to process
+	 * @param calibration
+	 *            The calibration, i.e., the voxel sizes in some unit for the
+	 *            input image.
+	 * @param sigmaSmaller
+	 *            sigma for the smaller scale in the same units as calibration.
+	 * @param sigmaLarger
+	 *            sigma for the larger scale in the same units as calibration.
+	 * @param extremaType
+	 *            which type of extrema (minima, maxima) to detect. Note that
+	 *            minima in the Difference-of-Gaussian correspond to bright
+	 *            blobs on dark background. Maxima correspond to dark blobs on
+	 *            bright background.
+	 * @param minPeakValue
+	 *            threshold value for detected extrema. Maxima below
+	 *            {@code minPeakValue} or minima above {@code -minPeakValue}
+	 *            will be disregarded.
+	 * @param normalizeMinPeakValue
+	 *            Whether the peak value should be normalized. The
+	 *            Difference-of-Gaussian is an approximation of the
+	 *            scale-normalized Laplacian-of-Gaussian, with a factor of
+	 *            <em>f = sigmaSmaller / (sigmaLarger - sigmaSmaller)</em>. If
+	 *            {@code normalizeMinPeakValue=true}, the {@code minPeakValue}
+	 *            will be divided by <em>f</em> (which is equivalent to scaling
+	 *            the DoG by <em>f</em>).
+	 * @param computationType
+	 *            The type to use for computing the Difference-of-Gaussian.
+	 */
+	public < F extends RealType< F > & NativeType< F > > DogDetection(
+			final RandomAccessible< T > input,
+			final Interval interval,
+			final double[] calibration,
+			final double sigmaSmaller,
+			final double sigmaLarger,
+			final ExtremaType extremaType,
+			final double minPeakValue,
+			final boolean normalizeMinPeakValue,
+			final F computationType )
+	{
 		this.input = input;
 		this.interval = interval;
 		this.sigmaSmaller = sigmaSmaller;
 		this.sigmaLarger = sigmaLarger;
 		this.pixelSize = calibration;
+		this.typedDogDetection = new TypedDogDetection<>( computationType );
 		this.imageSigma = 0.5;
 		this.minf = 2;
 		this.extremaType = extremaType;
@@ -161,59 +215,12 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 	 */
 	public ArrayList< Point > getPeaks()
 	{
-		final ExecutorService service;
-		if ( executorService == null )
-			service = Executors.newFixedThreadPool( numThreads );
-		else
-			service = executorService;
-
-		final T type = Util.getTypeFromInterval( Views.interval( input, interval ) );
-		dogImg = Util.getArrayOrCellImgFactory( interval, type ).create( interval, type );
-		final long[] translation = new long[ interval.numDimensions() ];
-		interval.min( translation );
-		dogImg = Views.translate( dogImg, translation );
-
-		final double[][] sigmas = DifferenceOfGaussian.computeSigmas( imageSigma, minf, pixelSize, sigmaSmaller, sigmaLarger );
-		DifferenceOfGaussian.DoG( sigmas[ 0 ], sigmas[ 1 ], input, dogImg, service );
-		final T val = type.createVariable();
-		final double minValueT = type.getMinValue();
-		final double maxValueT = type.getMaxValue();
-		final LocalNeighborhoodCheck< Point, T > localNeighborhoodCheck;
-		final double normalization = normalizeMinPeakValue ? ( sigmaLarger / sigmaSmaller - 1.0 ) : 1.0;
-		switch ( extremaType )
-		{
-		case MINIMA:
-			val.setReal( Math.max( Math.min( -minPeakValue * normalization, maxValueT ), minValueT ) );
-			localNeighborhoodCheck = new LocalExtrema.MinimumCheck<>( val );
-			break;
-		case MAXIMA:
-		default:
-			val.setReal( Math.max( Math.min( minPeakValue * normalization, maxValueT ), minValueT ) );
-			localNeighborhoodCheck = new LocalExtrema.MaximumCheck<>( val );
-		}
-		final ArrayList< Point > peaks = LocalExtrema.findLocalExtrema( dogImg, localNeighborhoodCheck, service );
-		if ( !keepDoGImg )
-			dogImg = null;
-
-		if ( executorService == null )
-			service.shutdown();
-
-		return peaks;
+		return typedDogDetection.getPeaks();
 	}
 
 	public ArrayList< RefinedPeak< Point > > getSubpixelPeaks()
 	{
-		final boolean savedKeepDoGImg = keepDoGImg;
-		keepDoGImg = true;
-		final ArrayList< Point > peaks = getPeaks();
-		final SubpixelLocalization< Point, T > spl = new SubpixelLocalization<>( dogImg.numDimensions() );
-		spl.setAllowMaximaTolerance( true );
-		spl.setMaxNumMoves( 10 );
-		final ArrayList< RefinedPeak< Point > > refined = spl.process( peaks, dogImg, dogImg );
-		keepDoGImg = savedKeepDoGImg;
-		if ( !keepDoGImg )
-			dogImg = null;
-		return refined;
+		return typedDogDetection.getSubpixelPeaks();
 	}
 
 	protected final RandomAccessible< T > input;
@@ -226,7 +233,7 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 
 	protected final double[] pixelSize;
 
-	protected RandomAccessibleInterval< T > dogImg;
+	protected final TypedDogDetection< ? > typedDogDetection;
 
 	protected double imageSigma;
 
@@ -313,5 +320,95 @@ public class DogDetection< T extends RealType< T > & NativeType< T > >
 		for ( int d = 0; d < c.length; ++d )
 			c[ d ] = calib.axis( d ).scale();
 		return c;
+	}
+
+	private static class DogComputationType< F extends RealType< F > & NativeType< F > >
+	{
+		private final F type;
+
+		@SuppressWarnings( "unchecked" )
+		public DogComputationType(
+				final RandomAccessible< ? > input,
+				final Interval interval )
+		{
+			final Object t = Util.getTypeFromInterval( Views.interval( input, interval ) );
+			if ( t instanceof DoubleType )
+				type = ( F ) new DoubleType();
+			else
+				type = ( F ) new FloatType();
+		}
+
+		public F getType()
+		{
+			return type;
+		}
+	}
+
+	protected class TypedDogDetection< F extends RealType< F > & NativeType< F > >
+	{
+		protected final F type;
+
+		protected RandomAccessibleInterval< F > dogImg;
+
+		public TypedDogDetection( final F type )
+		{
+			this.type = type;
+		}
+
+		public ArrayList< Point > getPeaks()
+		{
+			final ExecutorService service;
+			if ( executorService == null )
+				service = Executors.newFixedThreadPool( numThreads );
+			else
+				service = executorService;
+
+			dogImg = Util.getArrayOrCellImgFactory( interval, type ).create( interval, type );
+			final long[] translation = new long[ interval.numDimensions() ];
+			interval.min( translation );
+			dogImg = Views.translate( dogImg, translation );
+
+			final double[][] sigmas = DifferenceOfGaussian.computeSigmas( imageSigma, minf, pixelSize, sigmaSmaller, sigmaLarger );
+			DifferenceOfGaussian.DoG( sigmas[ 0 ], sigmas[ 1 ], input, dogImg, service );
+			final F val = type.createVariable();
+			final double minValueT = type.getMinValue();
+			final double maxValueT = type.getMaxValue();
+			final LocalNeighborhoodCheck< Point, F > localNeighborhoodCheck;
+			final double normalization = normalizeMinPeakValue ? ( sigmaLarger / sigmaSmaller - 1.0 ) : 1.0;
+			switch ( extremaType )
+			{
+			case MINIMA:
+				val.setReal( Math.max( Math.min( -minPeakValue * normalization, maxValueT ), minValueT ) );
+				localNeighborhoodCheck = new LocalExtrema.MinimumCheck<>( val );
+				break;
+			case MAXIMA:
+			default:
+				val.setReal( Math.max( Math.min( minPeakValue * normalization, maxValueT ), minValueT ) );
+				localNeighborhoodCheck = new LocalExtrema.MaximumCheck<>( val );
+			}
+			final ArrayList< Point > peaks = LocalExtrema.findLocalExtrema( dogImg, localNeighborhoodCheck, service );
+			if ( !keepDoGImg )
+				dogImg = null;
+
+			if ( executorService == null )
+				service.shutdown();
+
+			return peaks;
+		}
+
+		public ArrayList< RefinedPeak< Point > > getSubpixelPeaks()
+		{
+			final boolean savedKeepDoGImg = keepDoGImg;
+			keepDoGImg = true;
+			final ArrayList< Point > peaks = getPeaks();
+			final SubpixelLocalization< Point, F > spl = new SubpixelLocalization<>( dogImg.numDimensions() );
+			spl.setAllowMaximaTolerance( true );
+			spl.setMaxNumMoves( 10 );
+			final ArrayList< RefinedPeak< Point > > refined = spl.process( peaks, dogImg, dogImg );
+			keepDoGImg = savedKeepDoGImg;
+			if ( !keepDoGImg )
+				dogImg = null;
+			return refined;
+		}
 	}
 }


### PR DESCRIPTION
Use clearer parameter names. Use FloatType or DoubleType for DoG computation, unless a computation type is explicitly specified.
