### PR TITLE
Add single-threaded version to LocalExtrema and allow for caller specified neighborhoods.

### DIFF
--- a/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
+++ b/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
@@ -138,7 +138,7 @@ public class LocalExtrema
 		final int nDim = source.numDimensions();
 		// Get biggest dimension after border subtraction. Parallelize along
 		// this dimension.
-		final int maxSizeDim = IntStream.range( 0, nDim ).mapToObj( d -> new ValuePair<>( d, source.dimension( d ) - 2 * borderSize[ d ] ) ).min( ( p1, p2 ) -> Long.compare( p1.getB(), p2.getB() ) ).get().getA();
+		final int maxSizeDim = IntStream.range( 0, nDim ).mapToObj( d -> new ValuePair<>( d, source.dimension( d ) - 2 * borderSize[ d ] ) ).max( ( p1, p2 ) -> Long.compare( p1.getB(), p2.getB() ) ).get().getA();
 		final int numThreads = Runtime.getRuntime().availableProcessors();
 		final int numTasks = Math.max( Math.min( maxSizeDim, numThreads * 20 ), 1 );
 

--- a/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
+++ b/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,37 +34,44 @@
 package net.imglib2.algorithm.localextrema;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.Point;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Sampler;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
-import net.imglib2.util.Intervals;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.ConstantUtils;
+import net.imglib2.util.ValuePair;
+import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 /**
  * Provides
  * {@link #findLocalExtrema(RandomAccessibleInterval, LocalNeighborhoodCheck, int)}
  * to find pixels that are extrema in their local neighborhood.
- * 
+ *
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
 public class LocalExtrema
 {
 	/**
 	 * A local extremum check.
-	 * 
+	 *
 	 * @param <P>
 	 *            A representation of the extremum. For example, this could be
 	 *            just a {@link Point} describing the location of the extremum.
@@ -73,13 +80,13 @@ public class LocalExtrema
 	 * @param <T>
 	 *            pixel type.
 	 */
-	public interface LocalNeighborhoodCheck< P, T extends Comparable< T > >
+	public interface LocalNeighborhoodCheck< P, T >
 	{
 		/**
 		 * Determine whether a pixel is a local extremum. If so, return a
 		 * <code>P</code> that represents the maximum. Otherwise return
 		 * <code>null</code>.
-		 * 
+		 *
 		 * @param center
 		 *            an access located on the pixel to test
 		 * @param neighborhood
@@ -92,79 +99,286 @@ public class LocalExtrema
 
 	/**
 	 * Find pixels that are extrema in their local neighborhood. The specific
-	 * test for being an extremum can is specified as an implementation of the
+	 * test for being an extremum can be specified as an implementation of the
 	 * {@link LocalNeighborhoodCheck} interface.
-	 * 
-	 * TODO: Make neighborhood shape configurable. This will require that Shape
-	 * can give a bounding box.
-	 * 
-	 * @param img
+	 *
+	 * The task is parallelized along the longest dimension of <code>img</code>
+	 * after adjusting for size based on <code>shape</code>.
+	 *
+	 * The number of tasks for parallelization is determined as:
+	 * <code>Math.max( Math.min( maxSizeDim, numThreads * 20 ), 1 )</code>
+	 *
+	 * where <code>maxSizeDim</code> is the longest dimension of
+	 * <code>img</code> after adjusting for the bounding box of a
+	 * {@link RectangleShape} with span 1, and numThreads is
+	 * <code>Runtime.getRuntime().availableProcessors()</code>
+	 *
+	 * {@link RectangleShape} is used as local neighborhood.
+	 *
+	 * Note: Pixels within 1 point of the <code>source</code> border will be
+	 * ignored as local extrema candidates because the complete neighborhood
+	 * would not be included in <code>source</code>. To include those pixel,
+	 * expand <code>source</code> accordingly. The returned coordinate list is
+	 * valid for the original <code>source</code>.
+	 *
+	 * @param source
+	 *            Find local extrema within this
+	 *            {@link RandomAccessibleInterval}
 	 * @param localNeighborhoodCheck
+	 *            Check if current pixel qualifies as local maximum.
 	 * @param service
-	 * @return
+	 *            {@link ExecutorService} handles parallel tasks
+	 * @return {@link ArrayList} of extrema
 	 */
-	public static < P, T extends Comparable< T > > ArrayList< P > findLocalExtrema( final RandomAccessibleInterval< T > img, final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck, final ExecutorService service )
+	public static < P, T > ArrayList< P > findLocalExtrema( final RandomAccessibleInterval< T > source, final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck, final ExecutorService service )
 	{
-		final ArrayList< P > allExtrema = new ArrayList< P >();
-
-		final Interval full = Intervals.expand( img, -1 );
-		final int n = img.numDimensions();
-		final int splitd = n - 1;
-		// FIXME is there a better way to determine number of threads
-		final int numThreads = Runtime.getRuntime().availableProcessors();
-		final int numTasks = Math.max( Math.min( ( int ) full.dimension( splitd ), numThreads * 20 ), 1 );
-		final long dsize = full.dimension( splitd ) / numTasks;
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		full.min( min );
-		full.max( max );
-
 		final RectangleShape shape = new RectangleShape( 1, true );
+		final long[] borderSize = getRequiredBorderSize( shape, source.numDimensions() );
+		final int nDim = source.numDimensions();
+		// Get biggest dimension after border subtraction. Parallelize along
+		// this dimension.
+		final int maxSizeDim = IntStream.range( 0, nDim ).mapToObj( d -> new ValuePair<>( d, source.dimension( d ) - 2 * borderSize[ d ] ) ).min( ( p1, p2 ) -> Long.compare( p1.getB(), p2.getB() ) ).get().getA();
+		final int numThreads = Runtime.getRuntime().availableProcessors();
+		final int numTasks = Math.max( Math.min( maxSizeDim, numThreads * 20 ), 1 );
 
-		final ArrayList< Future< Void > > futures = new ArrayList< Future< Void > >();
-		final List< P > synchronizedAllExtrema = Collections.synchronizedList( allExtrema );
-		for ( int taskNum = 0; taskNum < numTasks; ++taskNum )
+		return findLocalExtrema( source, localNeighborhoodCheck, shape, service, numTasks );
+	}
+
+	/**
+	 * Find pixels that are extrema in their local neighborhood. The specific
+	 * test for being an extremum can be specified as an implementation of the
+	 * {@link LocalNeighborhoodCheck} interface.
+	 *
+	 * The task is parallelized along the longest dimension of <code>img</code>
+	 * after adjusting for size based on <code>shape</code>.
+	 *
+	 * Note: Pixels within a margin of <code>source</code> border as determined
+	 * by {@link #getRequiredBorderSize(Shape, int)} will be ignored as local
+	 * extrema candidates because the complete neighborhood would not be
+	 * included in <code>source</code>. To include those pixel, expand
+	 * <code>source</code> accordingly. The returned coordinate list is valid
+	 * for the original <code>source</code>.
+	 *
+	 * @param source
+	 *            Find local extrema within this
+	 *            {@link RandomAccessibleInterval}
+	 * @param localNeighborhoodCheck
+	 *            Check if current pixel qualifies as local maximum. It is the
+	 *            callers responsibility to pass a
+	 *            {@link LocalNeighborhoodCheck} that avoids the center pixel if
+	 *            <code>shape</code> does not skip the center pixel.
+	 * @param shape
+	 *            Defines the local neighborhood.
+	 * @param service
+	 *            {@link ExecutorService} handles parallel tasks
+	 * @param numTasks
+	 *            Number of tasks for parallel execution
+	 * @return {@link ArrayList} of extrema
+	 */
+	public static < P, T > ArrayList< P > findLocalExtrema(
+			final RandomAccessibleInterval< T > source,
+			final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck,
+			final Shape shape,
+			final ExecutorService service,
+			final int numTasks )
+	{
+
+		final int nDim = source.numDimensions();
+		final long[] borderSize = getRequiredBorderSize( shape, source.numDimensions() );
+
+		final long[] shrinkMin = IntStream.range( 0, nDim ).mapToLong( d -> source.min( d ) + borderSize[ d ] ).toArray();
+		final long[] shrinkMax = IntStream.range( 0, nDim ).mapToLong( d -> source.max( d ) - borderSize[ d ] ).toArray();
+
+		final int maxSizeDim = IntStream.range( 0, nDim ).mapToObj( d -> new ValuePair<>( d, source.dimension( d ) - 2 * borderSize[ d ] ) ).min( ( p1, p2 ) -> Long.compare( p1.getB(), p2.getB() ) ).get().getA();
+		final long maxDimSize = source.dimension( maxSizeDim ) - 2 * borderSize[ maxSizeDim ];
+		final long maxDimMax = source.max( maxSizeDim ) - borderSize[ maxSizeDim ];
+		final long taskSize = Math.max( maxDimSize / numTasks, 1 );
+
+		final ArrayList< Callable< ArrayList< P > > > tasks = new ArrayList<>();
+
+		for ( long start = borderSize[ maxSizeDim ]; start <= maxDimMax; start += taskSize )
 		{
-			min[ splitd ] = full.min( splitd ) + taskNum * dsize;
-			max[ splitd ] = ( taskNum == numTasks - 1 ) ? full.max( splitd ) : min[ splitd ] + dsize - 1;
-			final RandomAccessibleInterval< T > source = Views.interval( img, new FinalInterval( min, max ) );
-			final ArrayList< P > extrema = new ArrayList< P >( 128 );
-			final Callable< Void > r = new Callable< Void >()
-			{
-				@Override
-				public Void call()
-				{
-					final Cursor< T > center = Views.flatIterable( source ).cursor();
-					for ( final Neighborhood< T > neighborhood : shape.neighborhoods( source ) )
-					{
-						center.fwd();
-						final P p = localNeighborhoodCheck.check( center, neighborhood );
-						if ( p != null )
-							extrema.add( p );
-					}
-					synchronizedAllExtrema.addAll( extrema );
-					return null;
-				}
-			};
-			futures.add( service.submit( r ) );
+			final long s = Math.max( start, borderSize[ maxSizeDim ] );
+			// need max here instead of dimension for constructor of
+			// FinalInterval
+			final long S = Math.min( start + taskSize - 1, maxDimMax );
+			tasks.add( () -> {
+				final long[] min = shrinkMin.clone();
+				final long[] max = shrinkMax.clone();
+				min[ maxSizeDim ] = s;
+				max[ maxSizeDim ] = S;
+				return findLocalExtrema( source, new FinalInterval( min, max ), localNeighborhoodCheck, shape );
+			} );
 		}
-		for ( final Future< Void > f : futures )
+
+		final ArrayList< P > extrema = new ArrayList<>();
+		// TODO It is probably better to throw exception than to use try/catch
+		// block and return potentially incomplete/inconsistent list of extrema.
+		// Returning an empty list on exception could be a compromise without
+		// changing the interface.
+		try
 		{
-			try
+			final List< Future< ArrayList< P > > > futures = service.invokeAll( tasks );
+			for ( final Future< ArrayList< P > > f : futures )
+				try
 			{
-				f.get();
-			}
-			catch ( final InterruptedException e )
-			{
-				e.printStackTrace();
+					extrema.addAll( f.get() );
 			}
 			catch ( final ExecutionException e )
 			{
+				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 		}
+		catch ( final InterruptedException e )
+		{
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return extrema;
 
-		return allExtrema;
+	}
+
+	/**
+	 * Find pixels that are extrema in their local neighborhood. The specific
+	 * test for being an extremum can be specified as an implementation of the
+	 * {@link LocalNeighborhoodCheck} interface.
+	 *
+	 * {@link RectangleShape} is used as local neighborhood.
+	 *
+	 * Note: Pixels within 1 point of the <code>source</code> border will be
+	 * ignored as local extrema candidates because the complete neighborhood
+	 * would not be included in <code>source</code>. To include those pixel,
+	 * expand <code>source</code> accordingly. The returned coordinate list is
+	 * valid for the original <code>source</code>.
+	 *
+	 * @param source
+	 *            Find local extrema within this
+	 *            {@link RandomAccessibleInterval}
+	 * @param localNeighborhoodCheck
+	 *            Check if current pixel qualifies as local maximum.
+	 * @return {@link ArrayList} of extrema
+	 */
+	public static < P, T > ArrayList< P > findLocalExtrema(
+			final RandomAccessibleInterval< T > source,
+			final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck )
+	{
+		return findLocalExtrema( source, localNeighborhoodCheck, new RectangleShape( 1, true ) );
+	}
+
+	/**
+	 * Find pixels that are extrema in their local neighborhood. The specific
+	 * test for being an extremum can be specified as an implementation of the
+	 * {@link LocalNeighborhoodCheck} interface.
+	 *
+	 * Note: Pixels within a margin of <code>source</code> border as determined
+	 * by {@link #getRequiredBorderSize(Shape, int)} will be ignored as local
+	 * extrema candidates because the complete neighborhood would not be
+	 * included in <code>source</code>. To include those pixel, expand
+	 * <code>source</code> accordingly. The returned coordinate list is valid
+	 * for the original <code>source</code>.
+	 *
+	 * @param source
+	 *            Find local extrema within this
+	 *            {@link RandomAccessibleInterval}
+	 * @param localNeighborhoodCheck
+	 *            Check if current pixel qualifies as local maximum. It is the
+	 *            callers responsibility to pass a
+	 *            {@link LocalNeighborhoodCheck} that avoids the center pixel if
+	 *            <code>shape</code> does not skip the center pixel.
+	 * @param shape
+	 *            Defines the local neighborhood
+	 * @return {@link ArrayList} of extrema
+	 */
+	public static < P, T > ArrayList< P > findLocalExtrema(
+			final RandomAccessibleInterval< T > source,
+			final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck,
+			final Shape shape )
+	{
+
+		final long[] borderSize = getRequiredBorderSize( shape, source.numDimensions() );
+
+		assert Arrays.stream( borderSize ).min().getAsLong() >= 0: "Border size cannot be smaller than zero.";
+
+		// TODO use Intervals.expand once it is available in non-SNAPSHOT
+		// version
+		final int nDim = source.numDimensions();
+		final long[] min = IntStream.range( 0, nDim ).mapToLong( d -> source.min( d ) + borderSize[ d ] ).toArray();
+		final long[] max = IntStream.range( 0, nDim ).mapToLong( d -> source.max( d ) - borderSize[ d ] ).toArray();
+		return findLocalExtrema( source, new FinalInterval( min, max ), localNeighborhoodCheck, shape );
+	}
+
+	/**
+	 * Find pixels that are extrema in their local neighborhood. The specific
+	 * test for being an extremum can be specified as an implementation of the
+	 * {@link LocalNeighborhoodCheck} interface.
+	 *
+	 * @param source
+	 *            Find local extrema within this {@link RandomAccessible}
+	 * @param interval
+	 *            Specifies the domain within which to look for extrema
+	 * @param localNeighborhoodCheck
+	 *            Check if current pixel qualifies as local maximum. It is the
+	 *            callers responsibility to pass a
+	 *            {@link LocalNeighborhoodCheck} that avoids the center pixel if
+	 *            <code>shape</code> does not skip the center pixel.
+	 * @param shape
+	 *            Defines the local neighborhood
+	 * @return {@link ArrayList} of extrema
+	 */
+	public static < P, T > ArrayList< P > findLocalExtrema(
+			final RandomAccessible< T > source,
+			final Interval interval,
+			final LocalNeighborhoodCheck< P, T > localNeighborhoodCheck,
+			final Shape shape )
+	{
+
+		final IntervalView< T > sourceInterval = Views.interval( source, interval );
+
+		final ArrayList< P > extrema = new ArrayList<>();
+
+		final Cursor< T > center = Views.flatIterable( sourceInterval ).cursor();
+		for ( final Neighborhood< T > neighborhood : shape.neighborhoods( sourceInterval ) )
+		{
+			center.fwd();
+			final P p = localNeighborhoodCheck.check( center, neighborhood );
+			if ( p != null )
+				extrema.add( p );
+		}
+
+		return extrema;
+
+	}
+
+	/**
+	 *
+	 * Get the required border size based on the bounding box of the
+	 * neighborhood specified by <code>shape</code>. This is useful for
+	 * determining by how much a {@link RandomAccessibleInterval} should be
+	 * expanded to include min and max positions in the local extrema search.
+	 *
+	 * @param shape
+	 *            Defines the local neighborhood
+	 * @param nDim
+	 *            Number of dimensions.
+	 * @return The required border size for the local neighborhood specified by
+	 *         <code>shape</code>
+	 */
+	public static long[] getRequiredBorderSize( final Shape shape, final int nDim )
+	{
+		final RandomAccessible< Neighborhood< Object > > neighborhood = shape.neighborhoodsRandomAccessible( ConstantUtils.constantRandomAccessible( new Object(), nDim ) );
+		final long[] min = LongStream.generate( () -> Long.MAX_VALUE ).limit( nDim ).toArray();
+		final long[] max = LongStream.generate( () -> Long.MIN_VALUE ).limit( nDim ).toArray();
+		final Interval bb = neighborhood.randomAccess().get().getStructuringElementBoundingBox();
+
+		for ( int d = 0; d < nDim; ++d ) {
+			min[ d ] = Math.min( bb.min( d ), min[ d ] );
+			max[ d ] = Math.max( bb.max( d ), max[ d ] );
+		}
+
+		final long[] borderSize = IntStream.range( 0, nDim ).mapToLong( d -> Math.max( max[ d ], -min[ d ] ) ).toArray();
+
+		return borderSize;
 	}
 
 	/**
@@ -173,10 +387,10 @@ public class LocalExtrema
 	 * equal to a specified minimum allowed value, and no pixel in the
 	 * neighborhood has a greater value. That means that maxima are non-strict.
 	 * Intensity plateaus may result in multiple maxima.
-	 * 
+	 *
 	 * @param <T>
 	 *            pixel type.
-	 * 
+	 *
 	 * @author Tobias Pietzsch
 	 */
 	public static class MaximumCheck< T extends Comparable< T > > implements LocalNeighborhoodCheck< Point, T >
@@ -209,10 +423,10 @@ public class LocalExtrema
 	 * equal to a specified maximum allowed value, and no pixel in the
 	 * neighborhood has a smaller value. That means that minima are non-strict.
 	 * Intensity plateaus may result in multiple minima.
-	 * 
+	 *
 	 * @param <T>
 	 *            pixel type.
-	 * 
+	 *
 	 * @author Tobias Pietzsch
 	 */
 	public static class MinimumCheck< T extends Comparable< T > > implements LocalNeighborhoodCheck< Point, T >

--- a/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
+++ b/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
@@ -1,0 +1,208 @@
+package net.imglib2.algorithm.localextrema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.localextrema.LocalExtrema.MaximumCheck;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+public class LocalExtremaTest
+{
+
+	public static Comparator< Point > POINT_COMPARATOR = ( p1, p2 ) -> {
+		final int nDim = p1.numDimensions();
+		final int dimComp = Integer.compare( nDim, p2.numDimensions() );
+		if ( dimComp == 0 )
+		{
+			for ( int d = 0; d < nDim; ++d )
+			{
+				final int comp = Long.compare( p1.getLongPosition( d ), p2.getLongPosition( d ) );
+				if ( comp == 0 )
+					continue;
+				else
+					return comp;
+			}
+			return 0;
+		}
+		else
+			return dimComp;
+	};
+
+	public static int N_THREADS = Runtime.getRuntime().availableProcessors();
+
+	public static ExecutorService ES = Executors.newFixedThreadPool( N_THREADS );
+
+	public static int N_TASKS = 3 * N_THREADS;
+
+	@Test
+	public void test1D()
+	{
+		final double[] data = { 3.0, 0.0, 0.0, 1.0, 0.0, 1.0 };
+		final Point[] pointsNoBorder = { new Point( 3l ) };
+		final Point[] points = { new Point( 0l ), new Point( 3l ), new Point( 5l ) };
+
+		final List< Point > pnbList = Arrays.asList( pointsNoBorder );
+		final List< Point > pList = Arrays.asList( points );
+
+		Collections.sort( pnbList, POINT_COMPARATOR );
+		Collections.sort( pList, POINT_COMPARATOR );
+
+		final RectangleShape shape = new RectangleShape( 1, true );
+
+		final MaximumCheck< DoubleType > check = new LocalExtrema.MaximumCheck<>( new DoubleType( 0.0 ) );
+
+		final ArrayImg< DoubleType, DoubleArray > img = ArrayImgs.doubles( data, data.length );
+
+		test( img, check, shape, pnbList, POINT_COMPARATOR );
+		test( Views.extendValue( img, new DoubleType( -1.0 ) ), img, check, shape, pList, POINT_COMPARATOR );
+	}
+
+	// reference must be sorted
+	public static < T, P > void test(
+			final RandomAccessibleInterval< T > img,
+			final LocalExtrema.LocalNeighborhoodCheck< P, T > check,
+			final Shape shape,
+			final List< P > reference,
+			final Comparator< P > comp )
+	{
+		final ArrayList< P > extrema = LocalExtrema.findLocalExtrema( img, check, shape );
+		Assert.assertEquals( reference.size(), extrema.size() );
+		Collections.sort( extrema, comp );
+		Assert.assertEquals( reference, extrema );
+	}
+
+	public static < T, P > void test(
+			final RandomAccessible< T > img,
+			final Interval interval,
+			final LocalExtrema.LocalNeighborhoodCheck< P, T > check,
+			final Shape shape,
+			final List< P > reference,
+			final Comparator< P > comp )
+	{
+		final ArrayList< P > extrema = LocalExtrema.findLocalExtrema( img, interval, check, shape );
+		Assert.assertEquals( reference.size(), extrema.size() );
+		Collections.sort( extrema, comp );
+		Assert.assertEquals( reference, extrema );
+	}
+
+	@Test
+	public void testCheckBoard()
+	{
+		final int size = 4;
+		final RandomAccessibleInterval< IntType > cb = checkerBoard( new IntType(), size );
+
+		final Point[] pointsNoBorder = { new Point( 1, 2 ), new Point( 2, 1 ) };
+		final Point[] points = {
+				new Point( 0, 1 ), new Point( 0, 3 ),
+				new Point( 1, 0 ), new Point( 1, 2 ),
+				new Point( 2, 1 ), new Point( 2, 3 ),
+				new Point( 3, 0 ), new Point( 3, 2 )
+		};
+
+		final MaximumCheck< IntType > check = new LocalExtrema.MaximumCheck<>( new IntType( 0 ) );
+		final RectangleShape shape = new RectangleShape( 1, true );
+
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, check, shape ), POINT_COMPARATOR );
+		compare( Arrays.asList( points ), LocalExtrema.findLocalExtrema( Views.extendValue( cb, new IntType( 0 ) ), cb, check, shape ), POINT_COMPARATOR );
+
+		final List< Point > pointsOnBorder = Arrays.stream( points ).filter( p -> p.getLongPosition( 0 ) == 0 || p.getLongPosition( 1 ) == 0 || p.getLongPosition( 0 ) == size - 1 || p.getLongPosition( 1 ) == size - 1 ).collect( Collectors.toList() );
+
+		final RandomAccessibleInterval< IntType > emptyInside = chessBoardBorderOnly( new IntType(), size );
+		Assert.assertEquals( 0, LocalExtrema.findLocalExtrema( emptyInside, check, shape ).size() );
+		compare( pointsOnBorder, LocalExtrema.findLocalExtrema( Views.extendValue( emptyInside, new IntType( 0 ) ), emptyInside, check, shape ), POINT_COMPARATOR );
+
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, Intervals.expand( cb, -1 ), check, new RectangleShape( 1, true ) ), POINT_COMPARATOR );
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, check ), POINT_COMPARATOR );
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, check, new RectangleShape( 1, true ) ), POINT_COMPARATOR );
+
+	}
+
+	public static < P > void compare( final List< P > reference, final List< P > comparison, final Comparator< P > comp )
+	{
+		Assert.assertEquals( reference.size(), comparison.size() );
+		Collections.sort( reference, comp );
+		Collections.sort( comparison, comp );
+		Assert.assertEquals( reference, comparison );
+	}
+
+	@Test
+	public void testMultiThreaded()
+	{
+		final int size = 10;
+
+		final RandomAccessibleInterval< IntType > cb = checkerBoard( new IntType(), size );
+		final MaximumCheck< IntType > check = new LocalExtrema.MaximumCheck<>( new IntType( 0 ) );
+		final RectangleShape shape = new RectangleShape( 1, true );
+
+		final long nExtrema = Arrays.stream( Intervals.dimensionsAsLongArray( cb ) ).map( v -> ( v - 2 ) ).reduce( 1, ( i, j ) -> i * j ) / 2;
+
+		final ArrayList< Point > extremas1 = LocalExtrema.findLocalExtrema( cb, check, shape );
+		final ArrayList< Point > extremas2 = LocalExtrema.findLocalExtrema( cb, check, shape, ES, N_TASKS );
+		final ArrayList< Point > extremas3 = LocalExtrema.findLocalExtrema( cb, check, shape, ES, 1 );
+		final ArrayList< Point > extremas4 = LocalExtrema.findLocalExtrema( cb, check, shape );
+
+		Assert.assertEquals( nExtrema, extremas1.size() );
+		Assert.assertEquals( extremas1.size(), extremas2.size() );
+		Assert.assertEquals( extremas1.size(), extremas3.size() );
+		Assert.assertEquals( extremas1.size(), extremas4.size() );
+
+		Collections.sort( extremas1, POINT_COMPARATOR );
+		Collections.sort( extremas2, POINT_COMPARATOR );
+		Collections.sort( extremas3, POINT_COMPARATOR );
+		Collections.sort( extremas4, POINT_COMPARATOR );
+
+		Assert.assertEquals( extremas1, extremas2 );
+		Assert.assertEquals( extremas1, extremas3 );
+		Assert.assertEquals( extremas1, extremas4 );
+
+	}
+
+	// works for 2D only?
+	public static < T extends IntegerType< T > & NativeType< T > > RandomAccessibleInterval< T > checkerBoard( final T t, final long size )
+	{
+		final ArrayImg< T, ? > img = new ArrayImgFactory< T >().create( new long[] { size, size }, t );
+		for ( long x = 0; x < size; ++x )
+		{
+			final IntervalView< T > hs = Views.hyperSlice( img, 0, x );
+			final Cursor< T > c = hs.cursor();
+			for ( long val = x; c.hasNext(); ++val )
+				c.next().setInteger( val % 2 );
+		}
+		return img;
+	}
+
+	public static < T extends IntegerType< T > & NativeType< T > > RandomAccessibleInterval< T > chessBoardBorderOnly( final T t, final long size )
+	{
+		final RandomAccessibleInterval< T > cb = checkerBoard( t, size );
+		for ( final T i : Views.interval( cb, Intervals.expand( cb, -1 ) ) )
+			i.setZero();
+		return cb;
+	}
+
+}

--- a/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
+++ b/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
@@ -167,7 +167,12 @@ public class LocalExtremaTest
 		final RectangleShape shape = new RectangleShape( 1, true );
 
 		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, check, shape ), POINT_COMPARATOR );
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, LocalExtrema.shrink( cb, new long[] { 1, 1 } ), check ), POINT_COMPARATOR );
+		compare( Arrays.asList( pointsNoBorder ), LocalExtrema.findLocalExtrema( cb, check, ES ), POINT_COMPARATOR );
+
 		compare( Arrays.asList( points ), LocalExtrema.findLocalExtrema( Views.extendValue( cb, new IntType( 0 ) ), cb, check, shape ), POINT_COMPARATOR );
+		compare( Arrays.asList( points ), LocalExtrema.findLocalExtrema( Views.extendValue( cb, new IntType( 0 ) ), cb, check ), POINT_COMPARATOR );
+		compare( Arrays.asList( points ), LocalExtrema.findLocalExtrema( Views.interval( Views.extendValue( cb, new IntType( 0 ) ), Intervals.expand( cb, 1 ) ), check, ES ), POINT_COMPARATOR );
 
 		final List< Point > pointsOnBorder = Arrays.stream( points ).filter( p -> p.getLongPosition( 0 ) == 0 || p.getLongPosition( 1 ) == 0 || p.getLongPosition( 0 ) == size - 1 || p.getLongPosition( 1 ) == size - 1 ).collect( Collectors.toList() );
 

--- a/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
+++ b/src/test/java/net/imglib2/algorithm/localextrema/LocalExtremaTest.java
@@ -1,3 +1,36 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.algorithm.localextrema;
 
 import java.util.ArrayList;
@@ -32,6 +65,11 @@ import net.imglib2.util.Intervals;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ */
 public class LocalExtremaTest
 {
 


### PR DESCRIPTION


This commit adds:
  - shape parameter for callers to specify local neighborhood
  - Single-threaded version of findLocalExtrema
  - Parameter for caller to specify number of tasks.
  - Note in the JavaDoc to inform user that border pixels are ignored.
  - Relax the bounds on generic parameter T: Was Comparable< T >, now unbounded.

The original interface is preserved for a non-breaking change.

See also:
https://gitter.im/imglib/imglib2?at=58bd72101465c46a56f2ae9c