### PR TITLE
Remove duplicate <groupId> tag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
 		<relativePath />
 	</parent>
 
-	<groupId>net.imglib2</groupId>
 	<artifactId>imglib2-algorithm</artifactId>
 	<version>0.6.4-SNAPSHOT</version>
 


### PR DESCRIPTION
Duplicate caused a warning in eclipse. <groupId> already specified in parent.