### PR TITLE
Fix #42

### DIFF
--- a/src/main/java/net/imglib2/algorithm/gradient/PartialDerivative.java
+++ b/src/main/java/net/imglib2/algorithm/gradient/PartialDerivative.java
@@ -180,8 +180,8 @@ public class PartialDerivative
 			shiftback[ d ] = min[ d ] - max[ d ];
 
 		final RandomAccess< T > result = gradient.randomAccess();
-		final RandomAccess< T > back = source.randomAccess( Intervals.translate( gradient, 1, dimension ) );
-		final RandomAccess< T > front = source.randomAccess( Intervals.translate( gradient, -1, dimension ) );
+		final RandomAccess< T > back = source.randomAccess( Intervals.translate( gradient, -1, dimension ) );
+		final RandomAccess< T > front = source.randomAccess( Intervals.translate( gradient, 1, dimension ) );
 
 		result.setPosition( min );
 		back.setPosition( min );


### PR DESCRIPTION
`PartialDerivative.gradientCentralDifference` sets wrong interval bounds for forward/backward terms of finite difference.  Fixes #42 