### PR TITLE
Seperable Convolution with Asymmetric Kernels + Fast Gauss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 
+		<imglib2.version>5.6.0</imglib2.version>
 		<imglib2-realtransform.version>2.0.0-beta-39</imglib2-realtransform.version>
 		<jitk-tps.version>3.0.0</jitk-tps.version>
 		<ojalgo.version>43.0</ojalgo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,18 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>10.0.2</version>
+		<version>11.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -200,7 +200,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 
-		<imglib2.version>5.1.0</imglib2.version>
 		<imglib2-realtransform.version>2.0.0-beta-39</imglib2-realtransform.version>
 		<jitk-tps.version>3.0.0</jitk-tps.version>
 		<ojalgo.version>43.0</ojalgo.version>

--- a/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
@@ -1,20 +1,22 @@
 package net.imglib2.algorithm.convolution;
 
-import net.imglib2.RandomAccessible;
-import net.imglib2.RandomAccessibleInterval;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
 
 /**
  * Abstract class to help implementing a Convolution, that is multi threaded
  * using an {@link ExecutorService}. This implements the method
  * {@link Convolution#setExecutor(ExecutorService)}.
  * <p>
- * Classes that derive from
- * {@link AbstractMultiThreadedConvolution} must override
+ * Classes that derive from {@link AbstractMultiThreadedConvolution} must
+ * override
  * {@link AbstractMultiThreadedConvolution#process(RandomAccessible, RandomAccessibleInterval, ExecutorService, int)}
+ *
+ * @author Matthias Arzt
  */
 public abstract class AbstractMultiThreadedConvolution< T > implements Convolution< T >
 {
@@ -24,20 +26,21 @@ public abstract class AbstractMultiThreadedConvolution< T > implements Convoluti
 	abstract protected void process( RandomAccessible< ? extends T > source,
 			RandomAccessibleInterval< ? extends T > target,
 			ExecutorService executorService,
-			int numThreads);
+			int numThreads );
 
 	@Override
-	public void setExecutor( ExecutorService executor )
+	public void setExecutor( final ExecutorService executor )
 	{
 		this.executor = executor;
 	}
 
 	@Override
-	final public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	final public void process( final RandomAccessible< ? extends T > source, final RandomAccessibleInterval< ? extends T > target )
 	{
-		if(executor == null) {
-			int numThreads = suggestNumThreads();
-			ExecutorService executor = Executors.newFixedThreadPool( numThreads );
+		if ( executor == null )
+		{
+			final int numThreads = suggestNumThreads();
+			final ExecutorService executor = Executors.newFixedThreadPool( numThreads );
 			try
 			{
 				process( source, target, executor, numThreads );
@@ -47,12 +50,13 @@ public abstract class AbstractMultiThreadedConvolution< T > implements Convoluti
 				executor.shutdown();
 			}
 		}
-		else {
+		else
+		{
 			process( source, target, executor, getNumThreads( executor ) );
 		}
 	}
 
-	private int getNumThreads(ExecutorService executor)
+	private int getNumThreads( final ExecutorService executor )
 	{
 		if ( executor instanceof ThreadPoolExecutor )
 			return ( ( ThreadPoolExecutor ) executor ).getMaximumPoolSize();

--- a/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
@@ -1,0 +1,37 @@
+package net.imglib2.algorithm.convolution;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Abstract class to help implementing a Convolution, that is multi threaded
+ * using an {@link ExecutorService}. This implements the method
+ * {@link Convolution#setExecutor(ExecutorService)} and has useful protected
+ * methods {@link #getExecutor()} and {@link #getNumThreads()}.
+ */
+public abstract class AbstractMultiThreadedConvolution< T > implements Convolution< T >
+{
+	private ExecutorService executor = null;
+
+	@Override
+	public void setExecutor( ExecutorService executor )
+	{
+		this.executor = executor;
+	}
+
+	protected ExecutorService getExecutor()
+	{
+		if ( executor == null )
+			executor = Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() );
+		return executor;
+	}
+
+	protected int getNumThreads()
+	{
+		ExecutorService executor = getExecutor();
+		if ( executor instanceof ThreadPoolExecutor )
+			return ( ( ThreadPoolExecutor ) executor ).getMaximumPoolSize();
+		return Runtime.getRuntime().availableProcessors();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
@@ -1,5 +1,8 @@
 package net.imglib2.algorithm.convolution;
 
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -7,12 +10,21 @@ import java.util.concurrent.ThreadPoolExecutor;
 /**
  * Abstract class to help implementing a Convolution, that is multi threaded
  * using an {@link ExecutorService}. This implements the method
- * {@link Convolution#setExecutor(ExecutorService)} and has useful protected
- * methods {@link #getExecutor()} and {@link #getNumThreads()}.
+ * {@link Convolution#setExecutor(ExecutorService)}.
+ * <p>
+ * Classes that derive from
+ * {@link AbstractMultiThreadedConvolution} must override
+ * {@link AbstractMultiThreadedConvolution#process(RandomAccessible, RandomAccessibleInterval, ExecutorService, int)}
  */
 public abstract class AbstractMultiThreadedConvolution< T > implements Convolution< T >
 {
-	private ExecutorService executor = null;
+
+	private ExecutorService executor;
+
+	abstract protected void process( RandomAccessible< ? extends T > source,
+			RandomAccessibleInterval< ? extends T > target,
+			ExecutorService executorService,
+			int numThreads);
 
 	@Override
 	public void setExecutor( ExecutorService executor )
@@ -20,18 +32,35 @@ public abstract class AbstractMultiThreadedConvolution< T > implements Convoluti
 		this.executor = executor;
 	}
 
-	protected ExecutorService getExecutor()
+	@Override
+	final public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
 	{
-		if ( executor == null )
-			executor = Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() );
-		return executor;
+		if(executor == null) {
+			int numThreads = suggestNumThreads();
+			ExecutorService executor = Executors.newFixedThreadPool( numThreads );
+			try
+			{
+				process( source, target, executor, numThreads );
+			}
+			finally
+			{
+				executor.shutdown();
+			}
+		}
+		else {
+			process( source, target, executor, getNumThreads( executor ) );
+		}
 	}
 
-	protected int getNumThreads()
+	private int getNumThreads(ExecutorService executor)
 	{
-		ExecutorService executor = getExecutor();
 		if ( executor instanceof ThreadPoolExecutor )
 			return ( ( ThreadPoolExecutor ) executor ).getMaximumPoolSize();
+		return suggestNumThreads();
+	}
+
+	private int suggestNumThreads()
+	{
 		return Runtime.getRuntime().availableProcessors();
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
@@ -1,5 +1,10 @@
 package net.imglib2.algorithm.convolution;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -11,11 +16,6 @@ import net.imglib2.util.Util;
 import net.imglib2.util.ValuePair;
 import net.imglib2.view.Views;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-
 /**
  * Helper to implement {@link Convolution#concat}.
  *
@@ -26,18 +26,19 @@ class Concatenation< T > implements Convolution< T >
 
 	private final List< Convolution< T > > steps;
 
-	Concatenation( List< ? extends Convolution< T > > steps )
+	Concatenation( final List< ? extends Convolution< T > > steps )
 	{
 		this.steps = new ArrayList<>( steps );
 	}
 
-	@Override public void setExecutor( ExecutorService executor )
+	@Override
+	public void setExecutor( final ExecutorService executor )
 	{
 		steps.forEach( step -> step.setExecutor( executor ) );
 	}
 
 	@Override
-	public Interval requiredSourceInterval( Interval targetInterval )
+	public Interval requiredSourceInterval( final Interval targetInterval )
 	{
 		Interval result = targetInterval;
 		for ( int i = steps.size() - 1; i >= 0; i-- )
@@ -54,17 +55,17 @@ class Concatenation< T > implements Convolution< T >
 	}
 
 	@Override
-	public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	public void process( final RandomAccessible< ? extends T > source, final RandomAccessibleInterval< ? extends T > target )
 	{
-		List< Pair< T, Interval > > srcIntervals = tmpIntervals( Util.getTypeFromInterval( target ), target );
+		final List< Pair< T, Interval > > srcIntervals = tmpIntervals( Util.getTypeFromInterval( target ), target );
 		RandomAccessibleInterval< ? extends T > currentSource = Views.interval( source, srcIntervals.get( 0 ).getB() );
 		RandomAccessibleInterval< ? extends T > available = null;
 
 		for ( int i = 0; i < steps.size(); i++ )
 		{
-			Convolution< T > step = steps.get( i );
-			T targetType = srcIntervals.get( i + 1 ).getA();
-			Interval targetInterval = srcIntervals.get( i + 1 ).getB();
+			final Convolution< T > step = steps.get( i );
+			final T targetType = srcIntervals.get( i + 1 ).getA();
+			final Interval targetInterval = srcIntervals.get( i + 1 ).getB();
 			RandomAccessibleInterval< ? extends T > currentTarget =
 					( i == steps.size() - 1 ) ? target : null;
 
@@ -84,27 +85,28 @@ class Concatenation< T > implements Convolution< T >
 		}
 	}
 
-	private static < T extends NativeType< T > > RandomAccessibleInterval< T > createImage( T targetType, Interval targetInterval )
+	private static < T extends NativeType< T > > RandomAccessibleInterval< T > createImage( final T targetType, final Interval targetInterval )
 	{
-		long[] dimensions = Intervals.dimensionsAsLongArray( targetInterval );
-		Img< T > ts = Util.getArrayOrCellImgFactory( targetInterval, targetType ).create( dimensions );
+		final long[] dimensions = Intervals.dimensionsAsLongArray( targetInterval );
+		final Img< T > ts = Util.getArrayOrCellImgFactory( targetInterval, targetType ).create( dimensions );
 		return Views.translate( ts, Intervals.minAsLongArray( targetInterval ) );
 	}
 
-	private static < T > T uncheckedCast( Object in )
+	private static < T > T uncheckedCast( final Object in )
 	{
 		@SuppressWarnings( "unchecked" )
+		final
 		T in1 = ( T ) in;
 		return in1;
 	}
 
 	private List< Pair< T, Interval > > tmpIntervals( T type, Interval interval )
 	{
-		List< Pair< T, Interval > > result = new ArrayList<>( Collections.nCopies( steps.size() + 1, null ) );
+		final List< Pair< T, Interval > > result = new ArrayList<>( Collections.nCopies( steps.size() + 1, null ) );
 		result.set( steps.size(), new ValuePair<>( type, interval ) );
 		for ( int i = steps.size() - 1; i >= 0; i-- )
 		{
-			Convolution< T > step = steps.get( i );
+			final Convolution< T > step = steps.get( i );
 			interval = step.requiredSourceInterval( interval );
 			type = step.preferredSourceType( type );
 			result.set( i, new ValuePair<>( type, interval ) );

--- a/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
@@ -1,0 +1,131 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.Dimensions;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Pair;
+import net.imglib2.util.Util;
+import net.imglib2.util.ValuePair;
+import net.imglib2.view.Views;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Helper to implement {@link Convolution#concat}.
+ *
+ * @author Matthias Arzt
+ */
+class Concatenation< T > implements Convolution< T >
+{
+
+	private final List< Convolution< T > > steps;
+
+	Concatenation( List< ? extends Convolution< T > > steps )
+	{
+		this.steps = new ArrayList<>( steps );
+	}
+
+	@Override public void setExecutor( ExecutorService executor )
+	{
+		steps.forEach( step -> step.setExecutor( executor ) );
+	}
+
+	@Override
+	public Interval requiredSourceInterval( Interval targetInterval )
+	{
+		Interval result = targetInterval;
+		for ( int i = steps.size() - 1; i >= 0; i-- )
+			result = steps.get( i ).requiredSourceInterval( result );
+		return result;
+	}
+
+	@Override
+	public T preferredSourceType( T targetType )
+	{
+		for ( int i = steps.size() - 1; i >= 0; i-- )
+			targetType = steps.get( i ).preferredSourceType( targetType );
+		return targetType;
+	}
+
+	@Override
+	public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	{
+		List< Pair< T, Interval > > srcIntervals = tmpIntervals( Util.getTypeFromInterval( target ), target );
+		RandomAccessibleInterval< ? extends T > currentSource = Views.interval( source, srcIntervals.get( 0 ).getB() );
+		RandomAccessibleInterval< ? extends T > available = null;
+
+		for ( int i = 0; i < steps.size(); i++ )
+		{
+			Convolution< T > step = steps.get( i );
+			T targetType = srcIntervals.get( i + 1 ).getA();
+			Interval targetInterval = srcIntervals.get( i + 1 ).getB();
+			RandomAccessibleInterval< ? extends T > currentTarget =
+					( i == steps.size() - 1 ) ? target : null;
+
+			if ( currentTarget == null && available != null &&
+					Intervals.contains( available, targetInterval ) &&
+					Util.getTypeFromInterval( available ).getClass().equals( targetType.getClass() ) )
+				currentTarget = Views.interval( available, targetInterval );
+
+			if ( currentTarget == null )
+				currentTarget = createImage( uncheckedCast( targetType ), targetInterval );
+
+			step.process( currentSource, currentTarget );
+
+			if ( i > 0 )
+				available = currentSource;
+			currentSource = currentTarget;
+		}
+	}
+
+	private static < T extends NativeType< T > > RandomAccessibleInterval< T > createImage( T targetType, Interval targetInterval )
+	{
+		long[] dimensions = Intervals.dimensionsAsLongArray( targetInterval );
+		Img< T > ts = getImgFactory( targetInterval, targetType ).create( dimensions );
+		return Views.translate( ts, Intervals.minAsLongArray( targetInterval ) );
+	}
+
+	private static < T extends NativeType< T > > ImgFactory< T > getImgFactory( final Dimensions targetsize, final T type )
+	{
+		if ( canUseArrayImgFactory( targetsize ) )
+			return new ArrayImgFactory<>( type );
+		final int cellSize = ( int ) Math.pow( Integer.MAX_VALUE / type.getEntitiesPerPixel().getRatio(), 1.0 / targetsize.numDimensions() );
+		return new CellImgFactory<>( type, cellSize );
+	}
+
+	private static boolean canUseArrayImgFactory( final Dimensions targetsize )
+	{
+		return Intervals.numElements( targetsize ) <= Integer.MAX_VALUE;
+	}
+
+	private static < T > T uncheckedCast( Object in )
+	{
+		@SuppressWarnings( "unchecked" )
+		T in1 = ( T ) in;
+		return in1;
+	}
+
+	private List< Pair< T, Interval > > tmpIntervals( T type, Interval interval )
+	{
+		List< Pair< T, Interval > > result = new ArrayList<>( Collections.nCopies( steps.size() + 1, null ) );
+		result.set( steps.size(), new ValuePair<>( type, interval ) );
+		for ( int i = steps.size() - 1; i >= 0; i-- )
+		{
+			Convolution< T > step = steps.get( i );
+			interval = step.requiredSourceInterval( interval );
+			type = step.preferredSourceType( type );
+			result.set( i, new ValuePair<>( type, interval ) );
+		}
+		return result;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Concatenation.java
@@ -1,13 +1,9 @@
 package net.imglib2.algorithm.convolution;
 
-import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
-import net.imglib2.img.ImgFactory;
-import net.imglib2.img.array.ArrayImgFactory;
-import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
@@ -91,21 +87,8 @@ class Concatenation< T > implements Convolution< T >
 	private static < T extends NativeType< T > > RandomAccessibleInterval< T > createImage( T targetType, Interval targetInterval )
 	{
 		long[] dimensions = Intervals.dimensionsAsLongArray( targetInterval );
-		Img< T > ts = getImgFactory( targetInterval, targetType ).create( dimensions );
+		Img< T > ts = Util.getArrayOrCellImgFactory( targetInterval, targetType ).create( dimensions );
 		return Views.translate( ts, Intervals.minAsLongArray( targetInterval ) );
-	}
-
-	private static < T extends NativeType< T > > ImgFactory< T > getImgFactory( final Dimensions targetsize, final T type )
-	{
-		if ( canUseArrayImgFactory( targetsize ) )
-			return new ArrayImgFactory<>( type );
-		final int cellSize = ( int ) Math.pow( Integer.MAX_VALUE / type.getEntitiesPerPixel().getRatio(), 1.0 / targetsize.numDimensions() );
-		return new CellImgFactory<>( type, cellSize );
-	}
-
-	private static boolean canUseArrayImgFactory( final Dimensions targetsize )
-	{
-		return Intervals.numElements( targetsize ) <= Integer.MAX_VALUE;
 	}
 
 	private static < T > T uncheckedCast( Object in )

--- a/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
@@ -1,17 +1,17 @@
 package net.imglib2.algorithm.convolution;
 
-import net.imglib2.Interval;
-import net.imglib2.RandomAccessible;
-import net.imglib2.RandomAccessibleInterval;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
 /**
- * This interface allows the client to perform a convolution.
- * But also to query for the required input image size and preferred input image type.
- * The ExectorService can be set, to allow multi or single threaded operation.
+ * This interface allows the client to perform a convolution. But also to query
+ * for the required input image size and preferred input image type. The
+ * ExectorService can be set, to allow multi or single threaded operation.
  * <p>
  * Very importantly, multiple {@link Convolution}s can be easily concatenated.
  *
@@ -19,44 +19,46 @@ import java.util.concurrent.ExecutorService;
  */
 public interface Convolution< T >
 {
-
 	/**
-	 * Returns the required size for source image, to calculate the given target interval?
+	 * Returns the required size for source image, to calculate the given target
+	 * interval.
 	 */
 	Interval requiredSourceInterval( Interval targetInterval );
 
 	/**
-	 * What's the preferred type for the source image,
-	 * when target should have the specified type.
-	 **/
+	 * What's the preferred type for the source image, when target should have
+	 * the specified type?
+	 */
 	T preferredSourceType( T targetType );
 
 	/**
 	 * Set the {@link ExecutorService} to be used for convolution.
 	 */
-	default void setExecutor( ExecutorService executor )
-	{
-	}
+	default void setExecutor( final ExecutorService executor )
+	{}
 
 	/**
 	 * Fills the target image, with the convolution result.
 	 *
-	 * @param source Source image. It must allow pixel access in the interval returned
-	 *               by {@code requiredSourceInterval(target)}
-	 * @param target Target image.
+	 * @param source
+	 *            Source image. It must allow pixel access in the interval
+	 *            returned by {@code requiredSourceInterval(target)}
+	 * @param target
+	 *            Target image.
 	 */
 	void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target );
 
 	/**
-	 * Concatenate multiple {@link Convolution}s to one convolution.
-	 * (e.g. Concatenation of a gauss convolution in X, and a gauss convolution in Y will be a 2d gauss convolution).
+	 * Concatenate multiple {@link Convolution}s to one convolution. (e.g.
+	 * Concatenation of a gauss convolution in X, and a gauss convolution in Y
+	 * will be a 2d gauss convolution).
 	 */
-	static < T > Convolution< T > concat( Convolution< T >... steps )
+	static < T > Convolution< T > concat( final Convolution< T >... steps )
 	{
 		return concat( Arrays.asList( steps ) );
 	}
 
-	static < T > Convolution< T > concat( List< ? extends Convolution< T > > steps )
+	static < T > Convolution< T > concat( final List< ? extends Convolution< T > > steps )
 	{
 		if ( steps.isEmpty() )
 			throw new IllegalArgumentException( "Concat requires at least one convolution operation." );
@@ -65,4 +67,3 @@ public interface Convolution< T >
 		return new Concatenation<>( steps );
 	}
 }
-

--- a/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ExecutorService;
  * But also to query for the required input image size and preferred input image type.
  * The ExectorService can be set, to allow multi or single threaded operation.
  * <p>
- * Very imported multiple {@link Convolution}s can be easily concatenated.
+ * Very importantly, multiple {@link Convolution}s can be easily concatenated.
  *
  * @author Matthias Arzt
  */

--- a/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/Convolution.java
@@ -1,0 +1,68 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This interface allows the client to perform a convolution.
+ * But also to query for the required input image size and preferred input image type.
+ * The ExectorService can be set, to allow multi or single threaded operation.
+ * <p>
+ * Very imported multiple {@link Convolution}s can be easily concatenated.
+ *
+ * @author Matthias Arzt
+ */
+public interface Convolution< T >
+{
+
+	/**
+	 * Returns the required size for source image, to calculate the given target interval?
+	 */
+	Interval requiredSourceInterval( Interval targetInterval );
+
+	/**
+	 * What's the preferred type for the source image,
+	 * when target should have the specified type.
+	 **/
+	T preferredSourceType( T targetType );
+
+	/**
+	 * Set the {@link ExecutorService} to be used for convolution.
+	 */
+	default void setExecutor( ExecutorService executor )
+	{
+	}
+
+	/**
+	 * Fills the target image, with the convolution result.
+	 *
+	 * @param source Source image. It must allow pixel access in the interval returned
+	 *               by {@code requiredSourceInterval(target)}
+	 * @param target Target image.
+	 */
+	void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target );
+
+	/**
+	 * Concatenate multiple {@link Convolution}s to one convolution.
+	 * (e.g. Concatenation of a gauss convolution in X, and a gauss convolution in Y will be a 2d gauss convolution).
+	 */
+	static < T > Convolution< T > concat( Convolution< T >... steps )
+	{
+		return concat( Arrays.asList( steps ) );
+	}
+
+	static < T > Convolution< T > concat( List< ? extends Convolution< T > > steps )
+	{
+		if ( steps.isEmpty() )
+			throw new IllegalArgumentException( "Concat requires at least one convolution operation." );
+		if ( steps.size() == 1 )
+			return steps.get( 0 );
+		return new Concatenation<>( steps );
+	}
+}
+

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
@@ -99,7 +99,7 @@ public class LineConvolution< T > extends AbstractMultiThreadedConvolution< T >
 	{
 		long[] min = Intervals.minAsLongArray( interval );
 		long[] dim = Intervals.dimensionsAsLongArray( interval );
-		long size = LongStream.of( dim ).reduce( 1, ( a, b ) -> a * b );
+		long size = Intervals.numElements( dim );
 		final long endIndex = size;
 		final long taskSize = ( size + numTasks - 1 ) / numTasks; // round up
 		final ArrayList< Callable< Void > > callables = new ArrayList<>();

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
@@ -16,6 +16,10 @@ import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
@@ -51,7 +55,7 @@ public class LineConvolution< T > extends AbstractMultiThreadedConvolution< T >
 	@Override
 	public T preferredSourceType( final T targetType )
 	{
-		return targetType;
+		return (T) factory.preferredSourceType( targetType );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
@@ -85,7 +85,7 @@ public class LineConvolution< T > extends AbstractMultiThreadedConvolution< T >
 	/**
 	 * {@link #forEachIntervalElementInParallel(ExecutorService, int, Interval, Supplier)} executes a given action
 	 * for each position in a given interval. Therefor it starts the specified number of tasks. Each tasks calls
-	 * the action factory ones, to get an instance of the action that should be executed. The action is then called
+	 * the action factory once, to get an instance of the action that should be executed. The action is then called
 	 * multiple times by the task.
 	 *
 	 * @param service       {@link ExecutorService} used to create the tasks.

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolution.java
@@ -1,0 +1,149 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.IntervalIndexer;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.LongStream;
+
+/**
+ * This class can be used to implement a separable convolution.
+ * It applies a {@link LineConvolverFactory} on the given images.
+ *
+ * @author Matthias Arzt
+ */
+public class LineConvolution< T > extends AbstractMultiThreadedConvolution< T >
+{
+	private final LineConvolverFactory< ? super T > factory;
+
+	private final int direction;
+
+	public LineConvolution( LineConvolverFactory< ? super T > factory, int direction )
+	{
+		this.factory = factory;
+		this.direction = direction;
+	}
+
+	@Override public Interval requiredSourceInterval( Interval targetInterval )
+	{
+		long[] min = Intervals.minAsLongArray( targetInterval );
+		long[] max = Intervals.maxAsLongArray( targetInterval );
+		min[ direction ] -= factory.getBorderBefore();
+		max[ direction ] += factory.getBorderAfter();
+		return new FinalInterval( min, max );
+	}
+
+	@Override public T preferredSourceType( T targetType )
+	{
+		return targetType;
+	}
+
+	@Override public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	{
+		internConvolve( factory, Views.interval( source, requiredSourceInterval( target ) ), target, direction );
+	}
+
+	private < T > void internConvolve( LineConvolverFactory< ? super T > factory, RandomAccessibleInterval< ? extends T > source, RandomAccessibleInterval< ? extends T > target, int d )
+	{
+		final long[] sourceMin = Intervals.minAsLongArray( source );
+		final long[] targetMin = Intervals.minAsLongArray( target );
+
+		Supplier< Consumer< Localizable > > actionFactory = () -> {
+
+			final RandomAccess< ? extends T > in = source.randomAccess();
+			final RandomAccess< ? extends T > out = target.randomAccess();
+			final Runnable convolver = factory.getConvolver( in, out, d, target.dimension( d ) );
+
+			return position -> {
+				in.setPosition( sourceMin );
+				out.setPosition( targetMin );
+				in.move( position );
+				out.move( position );
+				convolver.run();
+			};
+		};
+
+		final long[] dim = Intervals.dimensionsAsLongArray( target );
+		dim[ d ] = 1;
+
+		// FIXME: is there a better way to determine the number of threads
+		final int numThreads = getNumThreads();
+		final int numTasks = numThreads > 1 ? numThreads * 4 : 1;
+		ExecutorService executorService = getExecutor();
+		LineConvolution.forEachIntervalElementInParallel( executorService, numTasks, new FinalInterval( dim ), actionFactory );
+	}
+
+	/**
+	 * {@link #forEachIntervalElementInParallel(ExecutorService, int, Interval, Supplier)} executes a given action
+	 * for each position in a given interval. Therefor it starts the specified number of tasks. Each tasks calls
+	 * the action factory ones, to get an instance of the action that should be executed. The action is then called
+	 * multiple times by the task.
+	 *
+	 * @param service       {@link ExecutorService} used to create the tasks.
+	 * @param numTasks      number of tasks to use.
+	 * @param interval      interval to iterate over.
+	 * @param actionFactory factory that returns the action to be executed.
+	 */
+	// TODO: move to a better place
+	public static void forEachIntervalElementInParallel( ExecutorService service, int numTasks, Interval interval,
+			Supplier< Consumer< Localizable > > actionFactory )
+	{
+		long[] min = Intervals.minAsLongArray( interval );
+		long[] dim = Intervals.dimensionsAsLongArray( interval );
+		long size = LongStream.of( dim ).reduce( 1, ( a, b ) -> a * b );
+		final long endIndex = size;
+		final long taskSize = ( size + numTasks - 1 ) / numTasks; // round up
+		final ArrayList< Callable< Void > > callables = new ArrayList<>();
+
+		for ( int taskNum = 0; taskNum < numTasks; ++taskNum )
+		{
+			final long myStartIndex = taskNum * taskSize;
+			final long myEndIndex = Math.min( endIndex, myStartIndex + taskSize );
+			final Callable< Void > r = () -> {
+				Consumer< Localizable > action = actionFactory.get();
+				final long[] position = new long[ dim.length ];
+				final Localizable localizable = Point.wrap( position );
+				for ( long index = myStartIndex; index < myEndIndex; ++index )
+				{
+					IntervalIndexer.indexToPositionWithOffset( index, dim, min, position );
+					action.accept( localizable );
+				}
+				return null;
+			};
+			callables.add( r );
+		}
+		execute( service, callables );
+	}
+
+	private static void execute( ExecutorService service, ArrayList< Callable< Void > > callables )
+	{
+		try
+		{
+			List< Future< Void > > futures = service.invokeAll( callables );
+			for ( Future< Void > future : futures )
+				future.get();
+		}
+		catch ( final InterruptedException | ExecutionException e )
+		{
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException )
+				throw ( RuntimeException ) cause;
+			throw new RuntimeException( e );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
@@ -1,0 +1,73 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.RandomAccess;
+
+/**
+ * The interesting part of a separable convolution is how one line of the
+ * image is convolved. An implementation of {@link LineConvolverFactory}
+ * needs to do exactly this: Convolve one line of the image.
+ * <p>
+ * All the "boring" stuff is done by {@link LineConvolution}, which takes
+ * care of applying {@link LineConvolverFactory} in a multi threaded fashion
+ * on an complete image.
+ */
+public interface LineConvolverFactory< T >
+{
+	/**
+	 * When doing a convolution, a neighborhood of a pixel needs to be known.
+	 * For line convolution, neighborhood means pixels before and after.
+	 *
+	 * @return How many pixels are needed before.
+	 */
+	long getBorderBefore();
+
+	/**
+	 * When doing a convolution, a neighborhood of a pixel needs to be known.
+	 * For line convolution, neighborhood means pixels before and after.
+	 *
+	 * @return How many pixels are needed after.
+	 */
+	long getBorderAfter();
+
+	/**
+	 * The {@link Runnable} returned by this method is responsible for convolving on line of
+	 * the image. But it will be reused. After the first line is convolved. The {@link RandomAccess}es
+	 * are moved to the start of the next line. And the Runnable is executed again.
+	 * {@link LineConvolution} works with multiple threads. {@link #getConvolver} is called once
+	 * per thread, and the returned {@link Runnable} is exclusively used in one thread.
+	 *
+	 * @param in         {@link RandomAccess}, that is positioned on the start of the line of the input image.
+	 * @param out        {@link RandomAccess}, that is positioned on the start of the line of the output image.
+	 * @param d          Dimension in which the line should go.
+	 * @param lineLength Length of the output line in pixels.
+	 * @return A {@link Runnable} that will read a line of the input image, convolve it, and write the
+	 * result to the output image.
+	 * (Input line length should be getBorderBefore() + lineLength + getBorderAfter())
+	 */
+	Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength );
+
+	static < S, T > LineConvolverFactory< T > wrapGauss3Convolver( double[] halfkernel, net.imglib2.algorithm.gauss3.ConvolverFactory< S, T > old )
+	{
+		return new LineConvolverFactory< T >()
+		{
+			@Override public long getBorderBefore()
+			{
+				return halfkernel.length - 1;
+			}
+
+			@Override public long getBorderAfter()
+			{
+				return halfkernel.length - 1;
+			}
+
+			@Override public Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength )
+			{
+				@SuppressWarnings( "unchecked" )
+				RandomAccess< S > in1 = ( RandomAccess< S > ) in;
+				@SuppressWarnings( "unchecked" )
+				RandomAccess< T > out1 = ( RandomAccess< T > ) out;
+				return old.create( halfkernel, in1, out1, d, lineLength );
+			}
+		};
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
@@ -45,29 +45,4 @@ public interface LineConvolverFactory< T >
 	 * (Input line length should be getBorderBefore() + lineLength + getBorderAfter())
 	 */
 	Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength );
-
-	static < S, T > LineConvolverFactory< T > wrapGauss3Convolver( double[] halfkernel, net.imglib2.algorithm.gauss3.ConvolverFactory< S, T > old )
-	{
-		return new LineConvolverFactory< T >()
-		{
-			@Override public long getBorderBefore()
-			{
-				return halfkernel.length - 1;
-			}
-
-			@Override public long getBorderAfter()
-			{
-				return halfkernel.length - 1;
-			}
-
-			@Override public Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength )
-			{
-				@SuppressWarnings( "unchecked" )
-				RandomAccess< S > in1 = ( RandomAccess< S > ) in;
-				@SuppressWarnings( "unchecked" )
-				RandomAccess< T > out1 = ( RandomAccess< T > ) out;
-				return old.create( halfkernel, in1, out1, d, lineLength );
-			}
-		};
-	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
@@ -3,13 +3,13 @@ package net.imglib2.algorithm.convolution;
 import net.imglib2.RandomAccess;
 
 /**
- * The interesting part of a separable convolution is how one line of the
- * image is convolved. An implementation of {@link LineConvolverFactory}
- * needs to do exactly this: Convolve one line of the image.
+ * The interesting part of a separable convolution is how one line of the image
+ * is convolved. An implementation of {@link LineConvolverFactory} needs to do
+ * exactly this: Convolve one line of the image.
  * <p>
- * All the "boring" stuff is done by {@link LineConvolution}, which takes
- * care of applying {@link LineConvolverFactory} in a multi threaded fashion
- * on an complete image.
+ * All the "boring" stuff is done by {@link LineConvolution}, which takes care
+ * of applying {@link LineConvolverFactory} in a multi threaded fashion on an
+ * complete image.
  */
 public interface LineConvolverFactory< T >
 {
@@ -30,19 +30,28 @@ public interface LineConvolverFactory< T >
 	long getBorderAfter();
 
 	/**
-	 * The {@link Runnable} returned by this method is responsible for convolving on line of
-	 * the image. But it will be reused. After the first line is convolved. The {@link RandomAccess}es
-	 * are moved to the start of the next line. And the Runnable is executed again.
-	 * {@link LineConvolution} works with multiple threads. {@link #getConvolver} is called once
-	 * per thread, and the returned {@link Runnable} is exclusively used in one thread.
+	 * The {@link Runnable} returned by this method is responsible for
+	 * convolving on line of the image. But it will be reused. After the first
+	 * line is convolved. The {@link RandomAccess}es are moved to the start of
+	 * the next line. And the Runnable is executed again.
+	 * {@link LineConvolution} works with multiple threads.
+	 * {@link #getConvolver} is called once per thread, and the returned
+	 * {@link Runnable} is exclusively used in one thread.
 	 *
-	 * @param in         {@link RandomAccess}, that is positioned on the start of the line of the input image.
-	 * @param out        {@link RandomAccess}, that is positioned on the start of the line of the output image.
-	 * @param d          Dimension in which the line should go.
-	 * @param lineLength Length of the output line in pixels.
-	 * @return A {@link Runnable} that will read a line of the input image, convolve it, and write the
-	 * result to the output image.
-	 * (Input line length should be getBorderBefore() + lineLength + getBorderAfter())
+	 * @param in
+	 *            {@link RandomAccess}, that is positioned on the start of the
+	 *            line of the input image.
+	 * @param out
+	 *            {@link RandomAccess}, that is positioned on the start of the
+	 *            line of the output image.
+	 * @param d
+	 *            Dimension in which the line should go.
+	 * @param lineLength
+	 *            Length of the output line in pixels.
+	 * @return A {@link Runnable} that will read a line of the input image,
+	 *         convolve it, and write the result to the output image. (Input
+	 *         line length should be getBorderBefore() + lineLength +
+	 *         getBorderAfter())
 	 */
 	Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength );
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/LineConvolverFactory.java
@@ -1,6 +1,7 @@
 package net.imglib2.algorithm.convolution;
 
 import net.imglib2.RandomAccess;
+import net.imglib2.type.Type;
 
 /**
  * The interesting part of a separable convolution is how one line of the image
@@ -54,4 +55,6 @@ public interface LineConvolverFactory< T >
 	 *         getBorderAfter())
 	 */
 	Runnable getConvolver( RandomAccess< ? extends T > in, RandomAccess< ? extends T > out, int d, long lineLength );
+
+	T preferredSourceType( T targetType );
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/MultiDimensionConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/MultiDimensionConvolution.java
@@ -1,0 +1,80 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.function.IntFunction;
+
+/**
+ * It's useful if there are multi {@link Convolution}s, each of which only
+ * works for a particular dimensionality. (e.g. gauss 1d, gauss 2d, gauss 3d, ...)
+ * {@link MultiDimensionConvolution} can be used to bundle them into one
+ * {@link Convolution} (e.g. gauss Nd).
+ *
+ * @author Matthias Arzt
+ */
+public class MultiDimensionConvolution< T > implements Convolution< T >
+{
+	private ExecutorService executor;
+
+	@Override public void setExecutor( ExecutorService executor )
+	{
+		this.executor = executor;
+		cache.values().forEach( convolution -> convolution.setExecutor( executor ) );
+	}
+
+	private final IntFunction< Convolution< T > > factory;
+
+	private final HashMap< Integer, Convolution< T > > cache = new HashMap<>();
+
+	/**
+	 * Constructor
+	 *
+	 * @param numDimensionToConvolution Function, when applied to a certain number (e.g. 2), it must
+	 *                                  return a {@link Convolution} that can be applied to images
+	 *                                  of that dimensions (e.g gauss 2d).
+	 */
+	public MultiDimensionConvolution( IntFunction< Convolution< T > > numDimensionToConvolution )
+	{
+		this.factory = numDimensionToConvolution;
+	}
+
+	private Convolution< T > getCachedConvolution( int nDimensions )
+	{
+		return cache.computeIfAbsent( nDimensions, n -> {
+			Convolution< T > c = factory.apply( n );
+			c.setExecutor( executor );
+			return c;
+		} );
+	}
+
+	/**
+	 * @see Convolution#requiredSourceInterval(Interval)
+	 */
+	@Override
+	public Interval requiredSourceInterval( Interval targetInterval )
+	{
+		return getCachedConvolution( targetInterval.numDimensions() ).requiredSourceInterval( targetInterval );
+	}
+
+	/**
+	 * @see Convolution#preferredSourceType(Object)
+	 */
+	@Override
+	public T preferredSourceType( T targetType )
+	{
+		return getCachedConvolution( 2 ).preferredSourceType( targetType );
+	}
+
+	/**
+	 * @see Convolution#process(RandomAccessible, RandomAccessibleInterval)
+	 */
+	@Override
+	public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	{
+		getCachedConvolution( target.numDimensions() ).process( source, target );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/MultiDimensionConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/MultiDimensionConvolution.java
@@ -1,16 +1,16 @@
 package net.imglib2.algorithm.convolution;
 
-import net.imglib2.Interval;
-import net.imglib2.RandomAccessible;
-import net.imglib2.RandomAccessibleInterval;
-
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.IntFunction;
 
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
 /**
- * It's useful if there are multi {@link Convolution}s, each of which only
- * works for a particular dimensionality. (e.g. gauss 1d, gauss 2d, gauss 3d, ...)
+ * It's useful if there are multi {@link Convolution}s, each of which only works
+ * for a particular dimensionality. (e.g. gauss 1d, gauss 2d, gauss 3d, ...)
  * {@link MultiDimensionConvolution} can be used to bundle them into one
  * {@link Convolution} (e.g. gauss Nd).
  *
@@ -20,7 +20,8 @@ public class MultiDimensionConvolution< T > implements Convolution< T >
 {
 	private ExecutorService executor;
 
-	@Override public void setExecutor( ExecutorService executor )
+	@Override
+	public void setExecutor( final ExecutorService executor )
 	{
 		this.executor = executor;
 		cache.values().forEach( convolution -> convolution.setExecutor( executor ) );
@@ -33,19 +34,20 @@ public class MultiDimensionConvolution< T > implements Convolution< T >
 	/**
 	 * Constructor
 	 *
-	 * @param numDimensionToConvolution Function, when applied to a certain number (e.g. 2), it must
-	 *                                  return a {@link Convolution} that can be applied to images
-	 *                                  of that dimensions (e.g gauss 2d).
+	 * @param numDimensionToConvolution
+	 *            Function, when applied to a certain number (e.g. 2), it must
+	 *            return a {@link Convolution} that can be applied to images of
+	 *            that dimensions (e.g gauss 2d).
 	 */
-	public MultiDimensionConvolution( IntFunction< Convolution< T > > numDimensionToConvolution )
+	public MultiDimensionConvolution( final IntFunction< Convolution< T > > numDimensionToConvolution )
 	{
 		this.factory = numDimensionToConvolution;
 	}
 
-	private Convolution< T > getCachedConvolution( int nDimensions )
+	private Convolution< T > getCachedConvolution( final int nDimensions )
 	{
 		return cache.computeIfAbsent( nDimensions, n -> {
-			Convolution< T > c = factory.apply( n );
+			final Convolution< T > c = factory.apply( n );
 			c.setExecutor( executor );
 			return c;
 		} );
@@ -55,7 +57,7 @@ public class MultiDimensionConvolution< T > implements Convolution< T >
 	 * @see Convolution#requiredSourceInterval(Interval)
 	 */
 	@Override
-	public Interval requiredSourceInterval( Interval targetInterval )
+	public Interval requiredSourceInterval( final Interval targetInterval )
 	{
 		return getCachedConvolution( targetInterval.numDimensions() ).requiredSourceInterval( targetInterval );
 	}
@@ -64,7 +66,7 @@ public class MultiDimensionConvolution< T > implements Convolution< T >
 	 * @see Convolution#preferredSourceType(Object)
 	 */
 	@Override
-	public T preferredSourceType( T targetType )
+	public T preferredSourceType( final T targetType )
 	{
 		return getCachedConvolution( 2 ).preferredSourceType( targetType );
 	}
@@ -73,7 +75,7 @@ public class MultiDimensionConvolution< T > implements Convolution< T >
 	 * @see Convolution#process(RandomAccessible, RandomAccessibleInterval)
 	 */
 	@Override
-	public void process( RandomAccessible< ? extends T > source, RandomAccessibleInterval< ? extends T > target )
+	public void process( final RandomAccessible< ? extends T > source, final RandomAccessibleInterval< ? extends T > target )
 	{
 		getCachedConvolution( target.numDimensions() ).process( source, target );
 	}

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
@@ -23,12 +23,14 @@ import java.util.stream.IntStream;
  * Faster alternative to {@link net.imglib2.algorithm.gauss3.Gauss3}.
  * It's especially faster if sigma is larger than 3.
  * <p>
- * It is normally expensive to calculate the exact result of the gauss convolution.
+ * It's expensive to calculate the exact result of the gaussian blur.
  * That's why approximations are almost always used.
  * {@link net.imglib2.algorithm.gauss3.Gauss3} does an approximation
- * by cutting of the gauss kernel at 3*sigma + 1.
- * {@link FastGauss} uses a different approach known as Fast Gauss
- * Transformation. The runtime is thereby independent of sigma.
+ * by cutting off the gauss kernel at 3*sigma + 1.
+ * {@link FastGauss} uses a different approach known as fast Gauss
+ * transformation. It's runtime is independent of sigma.
+ * <p>
+ * See {@link FastGaussCalculator} for more details.
  *
  * @author Vladimir Ulman
  * @author Matthias Arzt

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
@@ -1,0 +1,74 @@
+/*
+ * To the extent possible under law, the ImageJ developers have waived
+ * all copyright and related or neighboring rights to this code.
+ *
+ * See the CC0 1.0 Universal license for details:
+ *     http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package net.imglib2.algorithm.convolution.fast_gauss;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.convolution.Convolution;
+import net.imglib2.algorithm.convolution.LineConvolution;
+import net.imglib2.algorithm.convolution.MultiDimensionConvolution;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.RandomAccessibleInterval;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Faster alternative to {@link net.imglib2.algorithm.gauss3.Gauss3}.
+ * It's especially faster if sigma is larger than 3.
+ * <p>
+ * It is normally expensive to calculate the exact result of the gauss convolution.
+ * That's why approximations are almost always used.
+ * {@link net.imglib2.algorithm.gauss3.Gauss3} does an approximation
+ * by cutting of the gauss kernel at 3*sigma + 1.
+ * {@link FastGauss} uses a different approach known as Fast Gauss
+ * Transformation. The runtime is thereby independent of sigma.
+ *
+ * @author Vladimir Ulman
+ * @author Matthias Arzt
+ */
+public class FastGauss
+{
+
+	public static Convolution< RealType< ? > > convolution( double[] sigma )
+	{
+		List< Convolution< RealType< ? > > > steps = IntStream.range( 0, sigma.length )
+				.mapToObj( i -> convolution1d( sigma[ i ], i ) )
+				.collect( Collectors.toList() );
+		return Convolution.concat( steps );
+	}
+
+	public static Convolution< RealType< ? > > convolution( double sigma )
+	{
+		return new MultiDimensionConvolution<>( k -> convolution( nCopies( k, sigma ) ) );
+	}
+
+	public static Convolution< RealType< ? > > convolution1d( double sigma, int direction )
+	{
+		return new LineConvolution<>( new FastGaussConvolverRealType( sigma ), direction );
+	}
+
+	public static void convolve( double[] sigmas, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
+	{
+		convolution( sigmas ).process( input, output );
+	}
+
+	public static void convolve( double sigma, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
+	{
+		convolution( sigma ).process( input, output );
+	}
+
+	private static double[] nCopies( int n, double sigma )
+	{
+		double[] sigmas = new double[ n ];
+		Arrays.fill( sigmas, sigma );
+		return sigmas;
+	}
+
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
@@ -7,28 +7,28 @@
  */
 package net.imglib2.algorithm.convolution.fast_gauss;
 
-import net.imglib2.RandomAccessible;
-import net.imglib2.algorithm.convolution.Convolution;
-import net.imglib2.algorithm.convolution.LineConvolution;
-import net.imglib2.algorithm.convolution.MultiDimensionConvolution;
-import net.imglib2.type.numeric.RealType;
-import net.imglib2.RandomAccessibleInterval;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.convolution.Convolution;
+import net.imglib2.algorithm.convolution.LineConvolution;
+import net.imglib2.algorithm.convolution.MultiDimensionConvolution;
+import net.imglib2.type.numeric.RealType;
+
 /**
- * Faster alternative to {@link net.imglib2.algorithm.gauss3.Gauss3}.
- * It's especially faster if sigma is larger than 3.
+ * Faster alternative to {@link net.imglib2.algorithm.gauss3.Gauss3}. It's
+ * especially faster if sigma is larger than 3.
  * <p>
- * It's expensive to calculate the exact result of the gaussian blur.
- * That's why approximations are almost always used.
- * {@link net.imglib2.algorithm.gauss3.Gauss3} does an approximation
- * by cutting off the gauss kernel at 3*sigma + 1.
- * {@link FastGauss} uses a different approach known as fast Gauss
- * transformation. It's runtime is independent of sigma.
+ * It's expensive to calculate the exact result of the gaussian blur. That's why
+ * approximations are almost always used.
+ * {@link net.imglib2.algorithm.gauss3.Gauss3} does an approximation by cutting
+ * off the gauss kernel at 3*sigma + 1. {@link FastGauss} uses a different
+ * approach known as fast Gauss transformation. It's runtime is independent of
+ * sigma.
  * <p>
  * See {@link FastGaussCalculator} for more details.
  *
@@ -37,40 +37,38 @@ import java.util.stream.IntStream;
  */
 public class FastGauss
 {
-
-	public static Convolution< RealType< ? > > convolution( double[] sigma )
+	public static Convolution< RealType< ? > > convolution( final double[] sigma )
 	{
-		List< Convolution< RealType< ? > > > steps = IntStream.range( 0, sigma.length )
+		final List< Convolution< RealType< ? > > > steps = IntStream.range( 0, sigma.length )
 				.mapToObj( i -> convolution1d( sigma[ i ], i ) )
 				.collect( Collectors.toList() );
 		return Convolution.concat( steps );
 	}
 
-	public static Convolution< RealType< ? > > convolution( double sigma )
+	public static Convolution< RealType< ? > > convolution( final double sigma )
 	{
 		return new MultiDimensionConvolution<>( k -> convolution( nCopies( k, sigma ) ) );
 	}
 
-	public static Convolution< RealType< ? > > convolution1d( double sigma, int direction )
+	public static Convolution< RealType< ? > > convolution1d( final double sigma, final int direction )
 	{
 		return new LineConvolution<>( new FastGaussConvolverRealType( sigma ), direction );
 	}
 
-	public static void convolve( double[] sigmas, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
+	public static void convolve( final double[] sigmas, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
 	{
 		convolution( sigmas ).process( input, output );
 	}
 
-	public static void convolve( double sigma, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
+	public static void convolve( final double sigma, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
 	{
 		convolution( sigma ).process( input, output );
 	}
 
-	private static double[] nCopies( int n, double sigma )
+	private static double[] nCopies( final int n, final double sigma )
 	{
-		double[] sigmas = new double[ n ];
+		final double[] sigmas = new double[ n ];
 		Arrays.fill( sigmas, sigma );
 		return sigmas;
 	}
-
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
@@ -1,7 +1,14 @@
 package net.imglib2.algorithm.convolution.fast_gauss;
 
 /**
- * Fast algorithm to calculate an good approximation of the gauss convolution.
+ * This class implements the fast Gauss transform to calculate a gaussian blur.
+ * The approach is very different from an algorithm using a truncated convolution kernel.
+ * Especially the runtime is independent of sigma.
+ * <p>
+ * The implemented algorithm is described in detail in:
+ * Charalampidis, Dimitrios. "Recursive implementation of the Gaussian filter using
+ * truncated cosine functions." IEEE Transactions on Signal Processing 64.14
+ * (2016): 3554-3565.
  *
  * @author Vladimir Ulman
  * @author Matthias Arzt

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
@@ -2,13 +2,13 @@ package net.imglib2.algorithm.convolution.fast_gauss;
 
 /**
  * This class implements the fast Gauss transform to calculate a gaussian blur.
- * The approach is very different from an algorithm using a truncated convolution kernel.
- * Especially the runtime is independent of sigma.
+ * The approach is very different from an algorithm using a truncated
+ * convolution kernel. Especially the runtime is independent of sigma.
  * <p>
- * The implemented algorithm is described in detail in:
- * Charalampidis, Dimitrios. "Recursive implementation of the Gaussian filter using
- * truncated cosine functions." IEEE Transactions on Signal Processing 64.14
- * (2016): 3554-3565.
+ * The implemented algorithm is described in detail in: Charalampidis,
+ * Dimitrios. "Recursive implementation of the Gaussian filter using truncated
+ * cosine functions." IEEE Transactions on Signal Processing 64.14 (2016):
+ * 3554-3565.
  *
  * @author Vladimir Ulman
  * @author Matthias Arzt
@@ -16,18 +16,18 @@ package net.imglib2.algorithm.convolution.fast_gauss;
 public class FastGaussCalculator
 {
 	private final Parameters fc;
-	//we will utilize ring buffers whose current positions will be driven
-	//by the currently processed index inside the input array -- we will use
-	//bit masking to achieve fast the effect of the operation modulo, furthermore
-	//it does not suffer from sign effect: -5 % 8 = -5 in Java; I need it be +3
-	//to make it work nicely for the ring buffer (which cannot have negative indices)
-
-	//remember current plus last two results for every yk-term (there's M of them),
-	//so we need either 3*3 or 3*4=12 values => 4 bits = capacity for 16 values,
+	// we will utilize ring buffers whose current positions will be driven
+	// by the currently processed index inside the input array -- we will use
+	// bit masking to achieve fast the effect of the operation modulo, furthermore
+	// it does not suffer from sign effect: -5 % 8 = -5 in Java; I need it be +3
+	// to make it work nicely for the ring buffer (which cannot have negative indices)
+    //
+	// remember current plus last two results for every yk-term (there's M of them),
+	// so we need either 3*3 or 3*4=12 values => 4 bits = capacity for 16 values,
 	//
-	//actually, we will use 4 ring sub-buffers (each of length 4, 2 bits) for the
-	//individual yks...: y1, y3, y5, y7 (the order in which they are touched during
-	//the computation of the filter)
+	// actually, we will use 4 ring sub-buffers (each of length 4, 2 bits) for the
+	// individual yks...: y1, y3, y5, y7 (the order in which they are touched during
+	// the computation of the filter)
 	//
 	private final double[] yk0 = new double[ 4 ];
 
@@ -39,12 +39,12 @@ public class FastGaussCalculator
 
 	private int x;
 
-	public FastGaussCalculator( Parameters fc )
+	public FastGaussCalculator( final Parameters fc )
 	{
 		this.fc = fc;
 	}
 
-	public void initialize( double boundaryValue )
+	public void initialize( final double boundaryValue )
 	{
 		//calculate yk that one would get on constant signal of 1.0
 		//(Vlado's invention by solving eq. (35) assuming yk_n = yk_n-1 = yk_n-2)
@@ -62,7 +62,7 @@ public class FastGaussCalculator
 		yk3[ x & 3 ] = yk3[ ( x - 1 ) & 3 ] = boundaryValue * y7_mN;
 	}
 
-	public void update( double tmp )
+	public void update( final double tmp )
 	{
 		++x;
 		yk0[ x & 3 ] = fc.nk_2[ 0 ] * tmp - fc.dk_1[ 0 ] * yk0[ ( x - 1 ) & 3 ] - yk0[ ( x - 2 ) & 3 ];
@@ -77,23 +77,21 @@ public class FastGaussCalculator
 	}
 
 	/**
-	 * Collects all coefficients required to carry on the filtering, see eq. (35)
-	 * in the paper. If I(x) is your input array at offset x, and O(x) is supposed
-	 * to be the filtered output, one should do:
+	 * Collects all coefficients required to carry on the filtering, see eq.
+	 * (35) in the paper. If I(x) is your input array at offset x, and O(x) is
+	 * supposed to be the filtered output, one should do:
 	 * <p>
-	 * tmp = I(x-N-1) + I(x+N-1);
-	 * O(x)  = nk_2[0] * tmp  - dk_1[0] * yk(x-1)  - yk(x-2);
-	 * O(x) += nk_2[1] * tmp  - dk_1[1] * yk(x-1)  - yk(x-2);
-	 * O(x) += nk_2[2] * tmp  - dk_1[2] * yk(x-1)  - yk(x-2);
-	 * if M == 4:
-	 * O(x) += nk_2[3] * tmp  - dk_1[3] * yk(x-1)  - yk(x-2);
+	 * tmp = I(x-N-1) + I(x+N-1); O(x) = nk_2[0] * tmp - dk_1[0] * yk(x-1) -
+	 * yk(x-2); O(x) += nk_2[1] * tmp - dk_1[1] * yk(x-1) - yk(x-2); O(x) +=
+	 * nk_2[2] * tmp - dk_1[2] * yk(x-1) - yk(x-2); if M == 4: O(x) += nk_2[3] *
+	 * tmp - dk_1[3] * yk(x-1) - yk(x-2);
 	 * <p>
-	 * This way 2*M multiplications and 3*M additions are made per one 'x'.
-	 * Note that for-loop is not welcome as it involves comparison-test and
+	 * This way 2*M multiplications and 3*M additions are made per one 'x'. Note
+	 * that for-loop is not welcome as it involves comparison-test and
 	 * additional addition per one 'x'.
 	 * <p>
-	 * The class also stores Sigma for which the coefficients are valid
-	 * (as long as user is not changing values arbitrarily...).
+	 * The class also stores Sigma for which the coefficients are valid (as long
+	 * as user is not changing values arbitrarily...).
 	 */
 	public static class Parameters
 	{
@@ -127,8 +125,8 @@ public class FastGaussCalculator
 		}
 
 		/**
-		 * Construct with the same accuracy as the Gauss1D for which
-		 * you want to use it.
+		 * Construct with the same accuracy as the Gauss1D for which you want to
+		 * use it.
 		 */
 		private Parameters( final int _M, final double sigma )
 		{
@@ -139,10 +137,8 @@ public class FastGaussCalculator
 			dk_1 = new double[ 4 ];
 
 			// eq. (57), the filter width
-			final double N1 = ( int ) ( ( M == 3 ?
-					3.2795 * sigma + 0.25460 //M==3
-					:
-					3.7210 * sigma + 0.20157 //M==4
+			final double N1 = ( int ) ( ( M == 3 ? 3.2795 * sigma + 0.25460 // M==3
+					: 3.7210 * sigma + 0.20157 // M==4
 			) + 0.5 );
 
 			// Table I, 1st/top objective
@@ -163,7 +159,7 @@ public class FastGaussCalculator
 			final double r_5 = 1.0 * p_5 * p_5 / Math.sin( omega_5 );
 			final double r_7 = -1.0 * p_7 * p_7 / Math.sin( omega_7 );
 
-			//approximate rho_i:
+			// approximate rho_i:
 			// eq. (50) i=1,3,5,7
 			final double rho_1 = Math.exp( -0.5 * sigma * sigma * omega_1 * omega_1 ) / N1;
 			final double rho_3 = Math.exp( -0.5 * sigma * sigma * omega_3 * omega_3 ) / N1;
@@ -204,7 +200,7 @@ public class FastGaussCalculator
 			final double C_35 = D_51 / D_13;
 			final double C_37 = D_71 / D_13;
 
-			//get beta_k
+			// get beta_k
 			double beta_1, beta_3;
 			if ( M == 3 )
 			{
@@ -266,7 +262,7 @@ public class FastGaussCalculator
 			final double beta_5 = rho_5 + C_15 * ( rho_1 - beta_1 ) + C_35 * ( rho_3 - beta_3 );
 			final double beta_7 = rho_7 + C_17 * ( rho_1 - beta_1 ) + C_37 * ( rho_3 - beta_3 );
 
-			//fill the output container FilteringCoeffs
+			// fill the output container FilteringCoeffs
 			N = ( int ) N1;
 
 			nk_2[ 0 ] = -beta_1 * Math.cos( omega_1 * ( N1 + 1.0 ) );
@@ -281,12 +277,11 @@ public class FastGaussCalculator
 			{
 				nk_2[ 3 ] = -beta_7 * Math.cos( omega_7 * ( N1 + 1.0 ) );
 				dk_1[ 3 ] = -2.0 * Math.cos( omega_7 );
-				//NB: array length was guarded at the beginning of this function
+				// NB: array length was guarded at the beginning of this function
 			}
 
-			//declare to what sigma the coefficients belong to
+			// declare to what sigma the coefficients belong to
 			Sigma = sigma;
 		}
-
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussCalculator.java
@@ -1,0 +1,285 @@
+package net.imglib2.algorithm.convolution.fast_gauss;
+
+/**
+ * Fast algorithm to calculate an good approximation of the gauss convolution.
+ *
+ * @author Vladimir Ulman
+ * @author Matthias Arzt
+ */
+public class FastGaussCalculator
+{
+	private final Parameters fc;
+	//we will utilize ring buffers whose current positions will be driven
+	//by the currently processed index inside the input array -- we will use
+	//bit masking to achieve fast the effect of the operation modulo, furthermore
+	//it does not suffer from sign effect: -5 % 8 = -5 in Java; I need it be +3
+	//to make it work nicely for the ring buffer (which cannot have negative indices)
+
+	//remember current plus last two results for every yk-term (there's M of them),
+	//so we need either 3*3 or 3*4=12 values => 4 bits = capacity for 16 values,
+	//
+	//actually, we will use 4 ring sub-buffers (each of length 4, 2 bits) for the
+	//individual yks...: y1, y3, y5, y7 (the order in which they are touched during
+	//the computation of the filter)
+	//
+	private final double[] yk0 = new double[ 4 ];
+
+	private final double[] yk1 = new double[ 4 ];
+
+	private final double[] yk2 = new double[ 4 ];
+
+	private final double[] yk3 = new double[ 4 ];
+
+	private int x;
+
+	public FastGaussCalculator( Parameters fc )
+	{
+		this.fc = fc;
+	}
+
+	public void initialize( double boundaryValue )
+	{
+		//calculate yk that one would get on constant signal of 1.0
+		//(Vlado's invention by solving eq. (35) assuming yk_n = yk_n-1 = yk_n-2)
+		final double y1_mN = 2.0 * fc.nk_2[ 0 ] / ( fc.dk_1[ 0 ] + 2.0 );
+		final double y3_mN = 2.0 * fc.nk_2[ 1 ] / ( fc.dk_1[ 1 ] + 2.0 );
+		final double y5_mN = 2.0 * fc.nk_2[ 2 ] / ( fc.dk_1[ 2 ] + 2.0 );
+		final double y7_mN = fc.M == 4 ? 2.0 * fc.nk_2[ 3 ] / ( fc.dk_1[ 3 ] + 2.0 ) : 0.0;
+
+		//calculate yk that one would get on constant signal of array[0],
+		//and use this value for yk[x-2] and yk[x-1] when x=-Nm1
+		x = -1;
+		yk0[ x & 3 ] = yk0[ ( x - 1 ) & 3 ] = boundaryValue * y1_mN;
+		yk1[ x & 3 ] = yk1[ ( x - 1 ) & 3 ] = boundaryValue * y3_mN;
+		yk2[ x & 3 ] = yk2[ ( x - 1 ) & 3 ] = boundaryValue * y5_mN;
+		yk3[ x & 3 ] = yk3[ ( x - 1 ) & 3 ] = boundaryValue * y7_mN;
+	}
+
+	public void update( double tmp )
+	{
+		++x;
+		yk0[ x & 3 ] = fc.nk_2[ 0 ] * tmp - fc.dk_1[ 0 ] * yk0[ ( x - 1 ) & 3 ] - yk0[ ( x - 2 ) & 3 ];
+		yk1[ x & 3 ] = fc.nk_2[ 1 ] * tmp - fc.dk_1[ 1 ] * yk1[ ( x - 1 ) & 3 ] - yk1[ ( x - 2 ) & 3 ];
+		yk2[ x & 3 ] = fc.nk_2[ 2 ] * tmp - fc.dk_1[ 2 ] * yk2[ ( x - 1 ) & 3 ] - yk2[ ( x - 2 ) & 3 ];
+		yk3[ x & 3 ] = fc.M == 4 ? fc.nk_2[ 3 ] * tmp - fc.dk_1[ 3 ] * yk3[ ( x - 1 ) & 3 ] - yk3[ ( x - 2 ) & 3 ] : 0;
+	}
+
+	public double getValue()
+	{
+		return yk0[ x & 3 ] + yk1[ x & 3 ] + yk2[ x & 3 ] + yk3[ x & 3 ];
+	}
+
+	/**
+	 * Collects all coefficients required to carry on the filtering, see eq. (35)
+	 * in the paper. If I(x) is your input array at offset x, and O(x) is supposed
+	 * to be the filtered output, one should do:
+	 * <p>
+	 * tmp = I(x-N-1) + I(x+N-1);
+	 * O(x)  = nk_2[0] * tmp  - dk_1[0] * yk(x-1)  - yk(x-2);
+	 * O(x) += nk_2[1] * tmp  - dk_1[1] * yk(x-1)  - yk(x-2);
+	 * O(x) += nk_2[2] * tmp  - dk_1[2] * yk(x-1)  - yk(x-2);
+	 * if M == 4:
+	 * O(x) += nk_2[3] * tmp  - dk_1[3] * yk(x-1)  - yk(x-2);
+	 * <p>
+	 * This way 2*M multiplications and 3*M additions are made per one 'x'.
+	 * Note that for-loop is not welcome as it involves comparison-test and
+	 * additional addition per one 'x'.
+	 * <p>
+	 * The class also stores Sigma for which the coefficients are valid
+	 * (as long as user is not changing values arbitrarily...).
+	 */
+	public static class Parameters
+	{
+		private final int M;
+
+		/**
+		 * the width of the filter
+		 */
+		public int N = 0;
+
+		/**
+		 * the filtering coefficients
+		 */
+		private final double[] nk_2;
+
+		private final double[] dk_1;
+
+		/**
+		 * just informational: Sigma for which the parameters were calculated
+		 */
+		private double Sigma = 0;
+
+		public static Parameters fast( final double sigma )
+		{
+			return new Parameters( 3, sigma );
+		}
+
+		public static Parameters exact( final double sigma )
+		{
+			return new Parameters( 4, sigma );
+		}
+
+		/**
+		 * Construct with the same accuracy as the Gauss1D for which
+		 * you want to use it.
+		 */
+		private Parameters( final int _M, final double sigma )
+		{
+			if ( sigma <= 0 )
+				throw new IllegalArgumentException( "Sigma must be positive." );
+			M = ( _M == 3 || _M == 4 ) ? _M : 3;
+			nk_2 = new double[ 4 ];
+			dk_1 = new double[ 4 ];
+
+			// eq. (57), the filter width
+			final double N1 = ( int ) ( ( M == 3 ?
+					3.2795 * sigma + 0.25460 //M==3
+					:
+					3.7210 * sigma + 0.20157 //M==4
+			) + 0.5 );
+
+			// Table I, 1st/top objective
+			final double omega_1 = 1.0 * Math.PI / ( 2.0 * N1 );
+			final double omega_3 = 3.0 * Math.PI / ( 2.0 * N1 );
+			final double omega_5 = 5.0 * Math.PI / ( 2.0 * N1 );
+			final double omega_7 = 7.0 * Math.PI / ( 2.0 * N1 );
+
+			// eq. (37) i=1,3,5,7
+			final double p_1 = 1.0 / Math.tan( 0.5 * omega_1 );
+			final double p_3 = -1.0 / Math.tan( 0.5 * omega_3 );
+			final double p_5 = 1.0 / Math.tan( 0.5 * omega_5 );
+			final double p_7 = -1.0 / Math.tan( 0.5 * omega_7 );
+
+			// eq. (44) i=1,3,5,7
+			final double r_1 = 1.0 * p_1 * p_1 / Math.sin( omega_1 );
+			final double r_3 = -1.0 * p_3 * p_3 / Math.sin( omega_3 );
+			final double r_5 = 1.0 * p_5 * p_5 / Math.sin( omega_5 );
+			final double r_7 = -1.0 * p_7 * p_7 / Math.sin( omega_7 );
+
+			//approximate rho_i:
+			// eq. (50) i=1,3,5,7
+			final double rho_1 = Math.exp( -0.5 * sigma * sigma * omega_1 * omega_1 ) / N1;
+			final double rho_3 = Math.exp( -0.5 * sigma * sigma * omega_3 * omega_3 ) / N1;
+			final double rho_5 = Math.exp( -0.5 * sigma * sigma * omega_5 * omega_5 ) / N1;
+			final double rho_7 = Math.exp( -0.5 * sigma * sigma * omega_7 * omega_7 ) / N1;
+	/*
+			//accurate rho_i:
+			// eq. (50) i=1,3,5,7
+			double rho_1 = 0, rho_3 = 0, rho_5 = 0, rho_7 = 0;
+			for (double n = -N; n <= N; n += 1.0)
+			{
+				rho_1 += Math.cos(n*0.5*1.0*Math.PI /N) * Math.exp(-0.5*n*n/(Sigma*Sigma));
+				rho_3 += Math.cos(n*0.5*3.0*Math.PI /N) * Math.exp(-0.5*n*n/(Sigma*Sigma));
+				rho_5 += Math.cos(n*0.5*5.0*Math.PI /N) * Math.exp(-0.5*n*n/(Sigma*Sigma));
+				rho_7 += Math.cos(n*0.5*7.0*Math.PI /N) * Math.exp(-0.5*n*n/(Sigma*Sigma));
+			}
+			rho_1 /= N * Math.sqrt(2.0*Math.PI) * Sigma;
+			rho_3 /= N * Math.sqrt(2.0*Math.PI) * Sigma;
+			rho_5 /= N * Math.sqrt(2.0*Math.PI) * Sigma;
+			rho_7 /= N * Math.sqrt(2.0*Math.PI) * Sigma;
+			//
+			System.out.println("Rho_1 = "+Rho_1+",\trho_1 = "+rho_1);
+			System.out.println("Rho_3 = "+Rho_3+",\trho_3 = "+rho_3);
+			System.out.println("Rho_5 = "+Rho_5+",\trho_5 = "+rho_5);
+			System.out.println("Rho_7 = "+Rho_7+",\trho_7 = "+rho_7);
+	*/
+
+			// eq. (52) a,b = 1,3; 3,5; 3,7; 5,1; 7,1
+			final double D_13 = p_1 * r_3 - p_3 * r_1;
+			final double D_35 = p_3 * r_5 - p_5 * r_3;
+			final double D_37 = p_3 * r_7 - p_7 * r_3;
+			final double D_51 = p_5 * r_1 - p_1 * r_5;
+			final double D_71 = p_7 * r_1 - p_1 * r_7;
+
+			// eq. (52) i=5,7
+			final double C_15 = D_35 / D_13;
+			final double C_17 = D_37 / D_13;
+			final double C_35 = D_51 / D_13;
+			final double C_37 = D_71 / D_13;
+
+			//get beta_k
+			double beta_1, beta_3;
+			if ( M == 3 )
+			{
+				//build 6 minor 2x2 matrices to invA by excluding i-th row and j-th column from invA,
+				//and calculate their determinant Dij with the Sarrus rule
+				//
+				//        | p_1  p_3  p_5 |
+				// invA = | r_1  r_3  r_5 |
+				//        | C_15 C_35  1  |
+
+				final double D11 = r_3 - r_5 * C_35;
+				final double D21 = p_3 - p_5 * C_35;
+				final double D31 = D_35;
+
+				final double D12 = r_1 - r_5 * C_15;
+				final double D22 = p_1 - p_5 * C_15;
+				final double D32 = -D_51;
+
+				final double det_invA = p_1 * D11 - r_1 * D21 + C_15 * D31;
+
+				// eq. (53), only first two rows of matrix A_N
+				beta_1 = ( +D11 - ( N1 * N1 - sigma * sigma ) * D21
+						+ ( C_15 * rho_1 + C_35 * rho_3 + rho_5 ) * D31 ) / det_invA;
+				beta_3 = ( -D12 + ( N1 * N1 - sigma * sigma ) * D22
+						- ( C_15 * rho_1 + C_35 * rho_3 + rho_5 ) * D32 ) / det_invA;
+			}
+			else
+			{ // M == 4
+				//build 8 minor 3x3 matrices to invA by excluding i-th row and j-th column from invA,
+				//and calculate their determinant Dij with the Sarrus rule
+				//
+				//        | p_1  p_3  p_5  p_7 |
+				//        | r_1  r_3  r_5  r_7 |
+				// invA = | C_15 C_35  1    0  |
+				//        | C_17 C_37  0    1  |
+
+				final double D11 = r_3 - r_5 * C_35 - r_7 * C_37;
+				final double D21 = p_3 - p_5 * C_35 - p_7 * C_37;
+				final double D31 = p_3 * r_5 + p_5 * r_7 + C_37 - p_5 * r_3 - p_7 * r_5 * C_37;
+				final double D41 = p_5 * r_7 * C_35 + p_7 * r_3 - p_3 * r_7 - p_7 * r_5 * C_35;
+
+				final double D12 = r_1 - r_5 * C_15 - r_7 * C_17;
+				final double D22 = p_1 - p_5 * C_15 - p_7 * C_17;
+				final double D32 = p_1 * r_5 + p_5 * r_7 * C_17 - p_5 * r_1 - p_7 * r_5 * C_17;
+				final double D42 = p_5 * r_7 * C_15 + p_7 * r_1 - p_1 * r_7 - p_7 * r_5 * C_15;
+
+				final double det_invA = p_1 * D11 - r_1 * D21 + C_15 * D31 - C_17 * D41;
+
+				// eq. (53), only first two rows of matrix A_N
+				beta_1 = ( +D11 - ( N1 * N1 - sigma * sigma ) * D21 + ( C_15 * rho_1 + C_35 * rho_3 + rho_5 ) * D31
+						- ( C_17 * rho_1 + C_37 * rho_3 + rho_7 ) * D41 ) / det_invA;
+				beta_3 = ( -D12 + ( N1 * N1 - sigma * sigma ) * D22 - ( C_15 * rho_1 + C_35 * rho_3 + rho_5 ) * D32
+						+ ( C_17 * rho_1 + C_37 * rho_3 + rho_7 ) * D42 ) / det_invA;
+			}
+
+			// eq. (49), since I didn't want to continue building A_N to be used in eq. (53),
+			// I found it too expensive to calculate D[1234][34] to get beta_[57] in the same
+			// way as beta_[13]
+			final double beta_5 = rho_5 + C_15 * ( rho_1 - beta_1 ) + C_35 * ( rho_3 - beta_3 );
+			final double beta_7 = rho_7 + C_17 * ( rho_1 - beta_1 ) + C_37 * ( rho_3 - beta_3 );
+
+			//fill the output container FilteringCoeffs
+			N = ( int ) N1;
+
+			nk_2[ 0 ] = -beta_1 * Math.cos( omega_1 * ( N1 + 1.0 ) );
+			nk_2[ 1 ] = -beta_3 * Math.cos( omega_3 * ( N1 + 1.0 ) );
+			nk_2[ 2 ] = -beta_5 * Math.cos( omega_5 * ( N1 + 1.0 ) );
+
+			dk_1[ 0 ] = -2.0 * Math.cos( omega_1 );
+			dk_1[ 1 ] = -2.0 * Math.cos( omega_3 );
+			dk_1[ 2 ] = -2.0 * Math.cos( omega_5 );
+
+			if ( M == 4 )
+			{
+				nk_2[ 3 ] = -beta_7 * Math.cos( omega_7 * ( N1 + 1.0 ) );
+				dk_1[ 3 ] = -2.0 * Math.cos( omega_7 );
+				//NB: array length was guarded at the beginning of this function
+			}
+
+			//declare to what sigma the coefficients belong to
+			Sigma = sigma;
+		}
+
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
@@ -6,6 +6,8 @@ import net.imglib2.RandomAccess;
 import net.imglib2.algorithm.convolution.LineConvolverFactory;
 import net.imglib2.loops.ClassCopyProvider;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 /**
  * Implementation of {@link LineConvolverFactory} that uses
@@ -42,6 +44,12 @@ public class FastGaussConvolverRealType implements LineConvolverFactory< RealTyp
 	{
 		final Object key = Arrays.asList( in.getClass(), out.getClass(), in.get().getClass(), out.get().getClass() );
 		return provider.newInstanceForKey( key, d, fc, in, out, lineLength );
+	}
+
+	@Override
+	public RealType< ? > preferredSourceType( RealType< ? > targetType )
+	{
+		return (targetType instanceof DoubleType) ? targetType : new FloatType();
 	}
 
 	public static class MyConvolver implements Runnable

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
@@ -1,0 +1,102 @@
+package net.imglib2.algorithm.convolution.fast_gauss;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.loops.ClassCopyProvider;
+import net.imglib2.type.numeric.RealType;
+
+import java.util.Arrays;
+
+/**
+ * Implementation of {@link LineConvolverFactory} that uses {@link FastGaussCalculator}
+ * to calculate a fast gauss convolution.
+ *
+ * @author Vladimir Ulman
+ * @author Matthias Arzt
+ */
+public class FastGaussConvolverRealType implements LineConvolverFactory< RealType< ? > >
+{
+
+	private final FastGaussCalculator.Parameters fc;
+
+	private static final ClassCopyProvider< Runnable > provider = new ClassCopyProvider<>( MyConvolver.class, Runnable.class );
+
+	public FastGaussConvolverRealType( double sigma )
+	{
+		this.fc = FastGaussCalculator.Parameters.exact( sigma );
+	}
+
+	@Override public long getBorderBefore()
+	{
+		return fc.N + 1;
+	}
+
+	@Override public long getBorderAfter()
+	{
+		return fc.N - 1;
+	}
+
+	@Override public Runnable getConvolver( RandomAccess< ? extends RealType< ? > > in, RandomAccess< ? extends RealType< ? > > out, int d, long lineLength )
+	{
+		Object key = Arrays.asList( in.getClass(), out.getClass(), in.get().getClass(), out.get().getClass() );
+		return provider.newInstanceForKey( key, d, fc, in, out, lineLength );
+	}
+
+	public static class MyConvolver implements Runnable
+	{
+		private final int d;
+
+		private final RandomAccess< ? extends RealType< ? > > in;
+
+		private final RandomAccess< ? extends RealType< ? > > out;
+
+		private final long lineLength;
+
+		private final FastGaussCalculator fg;
+
+		private final int offset;
+
+		private final double[] tmpE;
+
+		public MyConvolver( int d, FastGaussCalculator.Parameters fc, RandomAccess< ? extends RealType< ? > > in, RandomAccess< ? extends RealType< ? > > out, long lineLength )
+		{
+			if ( lineLength > Integer.MAX_VALUE )
+				throw new UnsupportedOperationException();
+			this.d = d;
+			this.in = in;
+			this.out = out;
+			this.lineLength = lineLength;
+			this.offset = 2 * fc.N;
+			this.tmpE = new double[ ( int ) lineLength + offset ];
+			this.fg = new FastGaussCalculator( fc );
+		}
+
+		@Override public void run()
+		{
+			//left boundary: x=-Nm1, such that tmp = I(0) + I(0),
+			//but we say x=-N to simplify the following code block a bit
+			for ( int i = 0; i < lineLength + offset; ++i )
+			{
+				tmpE[ i ] = in.get().getRealDouble(); //backward edge + forward edge
+				in.fwd( d );
+			}
+
+			//cache...
+			double boundaryValue = tmpE[ 0 ];
+
+			fg.initialize( boundaryValue );
+			for ( int i = -offset; i < 0; ++i )
+			{
+				fg.update( boundaryValue + tmpE[ i + offset ] );
+				in.fwd( d );
+			}
+
+			for ( int i = 0; i < lineLength; ++i )
+			{
+				fg.update( tmpE[ i ] + tmpE[ i + offset ] );
+				out.get().setReal( fg.getValue() );
+				out.fwd( d );
+			}
+		}
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
@@ -1,44 +1,46 @@
 package net.imglib2.algorithm.convolution.fast_gauss;
 
+import java.util.Arrays;
+
 import net.imglib2.RandomAccess;
 import net.imglib2.algorithm.convolution.LineConvolverFactory;
 import net.imglib2.loops.ClassCopyProvider;
 import net.imglib2.type.numeric.RealType;
 
-import java.util.Arrays;
-
 /**
- * Implementation of {@link LineConvolverFactory} that uses {@link FastGaussCalculator}
- * to calculate a fast Gauss transform.
+ * Implementation of {@link LineConvolverFactory} that uses
+ * {@link FastGaussCalculator} to calculate a fast Gauss transform.
  *
  * @author Vladimir Ulman
  * @author Matthias Arzt
  */
 public class FastGaussConvolverRealType implements LineConvolverFactory< RealType< ? > >
 {
-
 	private final FastGaussCalculator.Parameters fc;
 
 	private static final ClassCopyProvider< Runnable > provider = new ClassCopyProvider<>( MyConvolver.class, Runnable.class );
 
-	public FastGaussConvolverRealType( double sigma )
+	public FastGaussConvolverRealType( final double sigma )
 	{
 		this.fc = FastGaussCalculator.Parameters.exact( sigma );
 	}
 
-	@Override public long getBorderBefore()
+	@Override
+	public long getBorderBefore()
 	{
 		return fc.N + 1;
 	}
 
-	@Override public long getBorderAfter()
+	@Override
+	public long getBorderAfter()
 	{
 		return fc.N - 1;
 	}
 
-	@Override public Runnable getConvolver( RandomAccess< ? extends RealType< ? > > in, RandomAccess< ? extends RealType< ? > > out, int d, long lineLength )
+	@Override
+	public Runnable getConvolver( final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final int d, final long lineLength )
 	{
-		Object key = Arrays.asList( in.getClass(), out.getClass(), in.get().getClass(), out.get().getClass() );
+		final Object key = Arrays.asList( in.getClass(), out.getClass(), in.get().getClass(), out.get().getClass() );
 		return provider.newInstanceForKey( key, d, fc, in, out, lineLength );
 	}
 
@@ -58,7 +60,7 @@ public class FastGaussConvolverRealType implements LineConvolverFactory< RealTyp
 
 		private final double[] tmpE;
 
-		public MyConvolver( int d, FastGaussCalculator.Parameters fc, RandomAccess< ? extends RealType< ? > > in, RandomAccess< ? extends RealType< ? > > out, long lineLength )
+		public MyConvolver( final int d, final FastGaussCalculator.Parameters fc, final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final long lineLength )
 		{
 			if ( lineLength > Integer.MAX_VALUE )
 				throw new UnsupportedOperationException();
@@ -71,18 +73,19 @@ public class FastGaussConvolverRealType implements LineConvolverFactory< RealTyp
 			this.fg = new FastGaussCalculator( fc );
 		}
 
-		@Override public void run()
+		@Override
+		public void run()
 		{
-			//left boundary: x=-Nm1, such that tmp = I(0) + I(0),
-			//but we say x=-N to simplify the following code block a bit
+			// left boundary: x=-Nm1, such that tmp = I(0) + I(0),
+			// but we say x=-N to simplify the following code block a bit
 			for ( int i = 0; i < lineLength + offset; ++i )
 			{
-				tmpE[ i ] = in.get().getRealDouble(); //backward edge + forward edge
+				tmpE[ i ] = in.get().getRealDouble(); // backward edge + forward edge
 				in.fwd( d );
 			}
 
-			//cache...
-			double boundaryValue = tmpE[ 0 ];
+			// cache...
+			final double boundaryValue = tmpE[ 0 ];
 
 			fg.initialize( boundaryValue );
 			for ( int i = -offset; i < 0; ++i )

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussConvolverRealType.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 
 /**
  * Implementation of {@link LineConvolverFactory} that uses {@link FastGaussCalculator}
- * to calculate a fast gauss convolution.
+ * to calculate a fast Gauss transform.
  *
  * @author Vladimir Ulman
  * @author Matthias Arzt

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,9 +46,12 @@ import net.imglib2.type.numeric.NumericType;
  * {@link NativeType} representation. It implemented using a shifting window
  * buffer that is stored in a small {@link NativeType} image.
  *
- * @param <T> input and output type
+ * @param <T>
+ *            input and output type
+ *
  * @author Tobias Pietzsch
  * @author Matthias Arzt
+ *
  * @see LineConvolverFactory
  */
 public final class ConvolverNativeType< T extends NumericType< T > & NativeType< T > > implements Runnable

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.NumericType;
+
+/**
+ * A 1-dimensional line convolver that operates on all {@link NumericType} with
+ * {@link NativeType} representation. It implemented using a shifting window
+ * buffer that is stored in a small {@link NativeType} image.
+ *
+ * @param <T> input and output type
+ * @author Tobias Pietzsch
+ * @author Matthias Arzt
+ * @see LineConvolverFactory
+ */
+public final class ConvolverNativeType< T extends NumericType< T > & NativeType< T > > implements Runnable
+{
+
+	final private double[] kernel;
+
+	final private RandomAccess< ? extends T > in;
+
+	final private RandomAccess< ? extends T > out;
+
+	final private int d;
+
+	private final int k1k;
+
+	final private int k1k1;
+
+	final private long linelen;
+
+	final T b1;
+
+	final T b2;
+
+	final T tmp;
+
+	public ConvolverNativeType( final Kernel1D kernel, final RandomAccess< ? extends T > in, final RandomAccess< ? extends T > out, final int d, final long lineLength )
+	{
+		// NB: This constructor is used in ConvolverFactories. It needs to be public and have this exact signature.
+		this.in = in;
+		this.out = out;
+		this.d = d;
+		this.kernel = kernel.fullKernel().clone();
+
+		k1k = this.kernel.length;
+		k1k1 = k1k - 1;
+		linelen = lineLength;
+
+		T type = out.get();
+		final ArrayImg< T, ? > buf = new ArrayImgFactory< T >( type ).create( new long[] { k1k } );
+		b1 = buf.randomAccess().get();
+		b2 = buf.randomAccess().get();
+
+		tmp = type.createVariable();
+	}
+
+	private void prefill()
+	{
+		// add new values
+		final T w = in.get();
+		process( w );
+		in.fwd( d );
+	}
+
+	private void next()
+	{
+		// add new values
+		final T w = in.get();
+		process( w );
+		in.fwd( d );
+		b1.updateIndex( 0 );
+		out.get().set( b1 );
+		out.fwd( d );
+	}
+
+	private void process( T w )
+	{
+		// move buf contents down
+		for ( int i = 0; i < k1k1; ++i )
+		{
+			b2.updateIndex( i + 1 );
+			b1.updateIndex( i );
+			b1.set( b2 );
+		}
+
+		b1.updateIndex( k1k1 );
+		b1.setZero();
+
+		// loop
+		for ( int j = 0; j < k1k; ++j )
+		{
+			tmp.set( w );
+			tmp.mul( kernel[ j ] );
+			b1.updateIndex( j );
+			b1.add( tmp );
+		}
+	}
+
+	@Override
+	public void run()
+	{
+		for ( int i = 0; i < k1k1; ++i )
+			prefill();
+		for ( long i = 0; i < linelen; ++i )
+			next();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNativeType.java
@@ -54,25 +54,25 @@ import net.imglib2.type.numeric.NumericType;
 public final class ConvolverNativeType< T extends NumericType< T > & NativeType< T > > implements Runnable
 {
 
-	final private double[] kernel;
+	private final double[] kernel;
 
-	final private RandomAccess< ? extends T > in;
+	private final RandomAccess< ? extends T > in;
 
-	final private RandomAccess< ? extends T > out;
+	private final RandomAccess< ? extends T > out;
 
-	final private int d;
+	private final int d;
 
 	private final int k1k;
 
-	final private int k1k1;
+	private final int k1k1;
 
-	final private long linelen;
+	private final long linelen;
 
-	final T b1;
+	private final T b1;
 
-	final T b2;
+	private final T b2;
 
-	final T tmp;
+	private final T tmp;
 
 	public ConvolverNativeType( final Kernel1D kernel, final RandomAccess< ? extends T > in, final RandomAccess< ? extends T > out, final int d, final long lineLength )
 	{
@@ -86,8 +86,8 @@ public final class ConvolverNativeType< T extends NumericType< T > & NativeType<
 		k1k1 = k1k - 1;
 		linelen = lineLength;
 
-		T type = out.get();
-		final ArrayImg< T, ? > buf = new ArrayImgFactory< T >( type ).create( new long[] { k1k } );
+		final T type = out.get();
+		final ArrayImg< T, ? > buf = new ArrayImgFactory<>( type ).create( new long[] { k1k } );
 		b1 = buf.randomAccess().get();
 		b2 = buf.randomAccess().get();
 
@@ -113,7 +113,7 @@ public final class ConvolverNativeType< T extends NumericType< T > & NativeType<
 		out.fwd( d );
 	}
 
-	private void process( T w )
+	private void process( final T w )
 	{
 		// move buf contents down
 		for ( int i = 0; i < k1k1; ++i )

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
@@ -87,6 +87,7 @@ public final class ConvolverNumericType< T extends NumericType< T > > implements
 		buffer = ( T[] ) Array.newInstance( type.getClass(), k1k + 1 );
 		for ( int i = 0; i < k1k + 1; ++i )
 			buffer[ i ] = type.createVariable();
+		buffer[ k1k ].setZero();
 
 		tmp = type.createVariable();
 	}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -44,9 +44,12 @@ import net.imglib2.type.numeric.NumericType;
  * A 1-dimensional line convolver that operates on all {@link NumericType}. It
  * implemented using a shifting window buffer that is stored in a T[] array.
  *
- * @param <T> input and output type
+ * @param <T>
+ *            input and output type
+ *
  * @author Tobias Pietzsch
  * @author Matthias Arzt
+ *
  * @see LineConvolverFactory
  */
 public final class ConvolverNumericType< T extends NumericType< T > > implements Runnable
@@ -83,7 +86,7 @@ public final class ConvolverNumericType< T extends NumericType< T > > implements
 		k1k1 = k1k - 1;
 		linelen = lineLength;
 
-		T type = out.get();
+		final T type = out.get();
 		buffer = ( T[] ) Array.newInstance( type.getClass(), k1k + 1 );
 		for ( int i = 0; i < k1k + 1; ++i )
 			buffer[ i ] = type.createVariable();

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
@@ -1,0 +1,133 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.algorithm.convolution.kernel;
+
+import java.lang.reflect.Array;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.type.numeric.NumericType;
+
+/**
+ * A 1-dimensional line convolver that operates on all {@link NumericType}. It
+ * implemented using a shifting window buffer that is stored in a T[] array.
+ *
+ * @param <T> input and output type
+ * @author Tobias Pietzsch
+ * @author Matthias Arzt
+ * @see LineConvolverFactory
+ */
+public final class ConvolverNumericType< T extends NumericType< T > > implements Runnable
+{
+
+	final private double[] kernel;
+
+	final private RandomAccess< ? extends T > in;
+
+	final private RandomAccess< ? extends T > out;
+
+	final private int d;
+
+	final private int k1k1;
+
+	final private int k1k;
+
+	final private long fill2;
+
+	final private T[] buffer;
+
+	final private T tmp;
+
+	@SuppressWarnings( "unchecked" )
+	public ConvolverNumericType( final Kernel1D kernel, final RandomAccess< ? extends T > in, final RandomAccess< ? extends T > out, final int d, final long lineLength )
+	{
+		// NB: This constructor is used in ConvolverFactories. It needs to be public and have this exact signature.
+		this.in = in;
+		this.out = out;
+		this.d = d;
+		this.kernel = kernel.fullKernel().clone();
+
+		k1k = this.kernel.length;
+		k1k1 = k1k - 1;
+		fill2 = lineLength;
+
+		T type = out.get();
+		buffer = ( T[] ) Array.newInstance( type.getClass(), k1k + 1 );
+		for ( int i = 0; i < k1k + 1; ++i )
+			buffer[ i ] = type.createVariable();
+
+		tmp = type.createVariable();
+	}
+
+	private void prefill()
+	{
+		tmp.set( in.get() );
+		process( tmp );
+		in.fwd( d );
+	}
+
+	private void next()
+	{
+		tmp.set( in.get() );
+		final T t = buffer[ 0 ];
+		t.set( tmp );
+		t.mul( kernel[ 0 ] );
+		t.add( buffer[ 1 ] );
+		out.get().set( t );
+		process( tmp );
+		in.fwd( d );
+		out.fwd( d );
+	}
+
+	private void process( T tmp )
+	{
+		for ( int i = 1; i < k1k; ++i )
+		{
+			final T t = buffer[ i ];
+			t.set( tmp );
+			t.mul( kernel[ i ] );
+			t.add( buffer[ i + 1 ] );
+		}
+	}
+
+	@Override
+	public void run()
+	{
+		for ( int i = 0; i < k1k1; ++i )
+			prefill();
+		for ( long i = 0; i < fill2; ++i )
+			next();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/ConvolverNumericType.java
@@ -52,23 +52,23 @@ import net.imglib2.type.numeric.NumericType;
 public final class ConvolverNumericType< T extends NumericType< T > > implements Runnable
 {
 
-	final private double[] kernel;
+	private final double[] kernel;
 
-	final private RandomAccess< ? extends T > in;
+	private final RandomAccess< ? extends T > in;
 
-	final private RandomAccess< ? extends T > out;
+	private final RandomAccess< ? extends T > out;
 
-	final private int d;
+	private final int d;
 
-	final private int k1k1;
+	private final int k1k;
 
-	final private int k1k;
+	private final int k1k1;
 
-	final private long fill2;
+	private final long linelen;
 
-	final private T[] buffer;
+	private final T[] buffer;
 
-	final private T tmp;
+	private final T tmp;
 
 	@SuppressWarnings( "unchecked" )
 	public ConvolverNumericType( final Kernel1D kernel, final RandomAccess< ? extends T > in, final RandomAccess< ? extends T > out, final int d, final long lineLength )
@@ -81,7 +81,7 @@ public final class ConvolverNumericType< T extends NumericType< T > > implements
 
 		k1k = this.kernel.length;
 		k1k1 = k1k - 1;
-		fill2 = lineLength;
+		linelen = lineLength;
 
 		T type = out.get();
 		buffer = ( T[] ) Array.newInstance( type.getClass(), k1k + 1 );
@@ -111,7 +111,7 @@ public final class ConvolverNumericType< T extends NumericType< T > > implements
 		out.fwd( d );
 	}
 
-	private void process( T tmp )
+	private void process( final T tmp )
 	{
 		for ( int i = 1; i < k1k; ++i )
 		{
@@ -127,7 +127,7 @@ public final class ConvolverNumericType< T extends NumericType< T > > implements
 	{
 		for ( int i = 0; i < k1k1; ++i )
 			prefill();
-		for ( long i = 0; i < fill2; ++i )
+		for ( long i = 0; i < linelen; ++i )
 			next();
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
@@ -50,21 +50,21 @@ import net.imglib2.type.numeric.RealType;
 public final class DoubleConvolverRealType implements Runnable
 {
 
-	final private double[] kernel;
+	private final double[] kernel;
 
-	final private RandomAccess< ? extends RealType< ? > > in;
+	private final RandomAccess< ? extends RealType< ? > > in;
 
-	final private RandomAccess< ? extends RealType< ? > > out;
+	private final RandomAccess< ? extends RealType< ? > > out;
 
-	final private int d;
+	private final int d;
 
-	final private int k1k1;
+	private final int k1k;
 
-	final private int k1k;
+	private final int k1k1;
 
-	final private long fill2;
+	private final long linelen;
 
-	final private double[] buffer;
+	private final double[] buffer;
 
 	public DoubleConvolverRealType( final Kernel1D kernel, final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final int d, final long lineLength )
 	{
@@ -76,7 +76,7 @@ public final class DoubleConvolverRealType implements Runnable
 
 		k1k = this.kernel.length;
 		k1k1 = k1k - 1;
-		fill2 = lineLength;
+		linelen = lineLength;
 		buffer = new double[ k1k + 1 ];
 	}
 
@@ -107,7 +107,7 @@ public final class DoubleConvolverRealType implements Runnable
 	{
 		for ( int i = 0; i < k1k1; ++i )
 			prefill();
-		for ( long i = 0; i < fill2; ++i )
+		for ( long i = 0; i < linelen; ++i )
 			next();
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * A 1-dimensional line convolver that operates on all {@link RealType}. It
+ * implemented using a shifting window buffer that is stored in a small double[]
+ * array.
+ *
+ * @author Tobias Pietzsch
+ * @author Matthias Arzt
+ * @see LineConvolverFactory
+ */
+public final class DoubleConvolverRealType implements Runnable
+{
+
+	final private double[] kernel;
+
+	final private RandomAccess< ? extends RealType< ? > > in;
+
+	final private RandomAccess< ? extends RealType< ? > > out;
+
+	final private int d;
+
+	final private int k1k1;
+
+	final private int k1k;
+
+	final private long fill2;
+
+	final private double[] buffer;
+
+	public DoubleConvolverRealType( final Kernel1D kernel, final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final int d, final long lineLength )
+	{
+		// NB: This constructor is used in ConvolverFactories. It needs to be public and have this exact signature.
+		this.in = in;
+		this.out = out;
+		this.d = d;
+		this.kernel = kernel.fullKernel().clone();
+
+		k1k = this.kernel.length;
+		k1k1 = k1k - 1;
+		fill2 = lineLength;
+		buffer = new double[ k1k + 1 ];
+	}
+
+	private void prefill()
+	{
+		final double w = in.get().getRealDouble();
+		process( w );
+		in.fwd( d );
+	}
+
+	private void next()
+	{
+		final double w = in.get().getRealDouble();
+		out.get().setReal( w * kernel[ 0 ] + buffer[ 1 ] );
+		process( w );
+		in.fwd( d );
+		out.fwd( d );
+	}
+
+	private void process( double w )
+	{
+		for ( int i = 1; i < k1k; ++i )
+			buffer[ i ] = w * kernel[ i ] + buffer[ i + 1 ];
+	}
+
+	@Override
+	public void run()
+	{
+		for ( int i = 0; i < k1k1; ++i )
+			prefill();
+		for ( long i = 0; i < fill2; ++i )
+			next();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/DoubleConvolverRealType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -45,6 +45,7 @@ import net.imglib2.type.numeric.RealType;
  *
  * @author Tobias Pietzsch
  * @author Matthias Arzt
+ *
  * @see LineConvolverFactory
  */
 public final class DoubleConvolverRealType implements Runnable
@@ -96,7 +97,7 @@ public final class DoubleConvolverRealType implements Runnable
 		out.fwd( d );
 	}
 
-	private void process( double w )
+	private void process( final double w )
 	{
 		for ( int i = 1; i < k1k; ++i )
 			buffer[ i ] = w * kernel[ i ] + buffer[ i + 1 ];

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -45,6 +45,7 @@ import net.imglib2.type.numeric.RealType;
  *
  * @author Tobias Pietzsch
  * @author Matthias Arzt
+ *
  * @see LineConvolverFactory
  */
 public final class FloatConvolverRealType implements Runnable
@@ -80,9 +81,9 @@ public final class FloatConvolverRealType implements Runnable
 		buffer = new float[ k1k + 1 ];
 	}
 
-	private float[] doubleToFloat( double[] in )
+	private float[] doubleToFloat( final double[] in )
 	{
-		float[] out = new float[ in.length ];
+		final float[] out = new float[ in.length ];
 		for ( int i = 0; i < in.length; i++ )
 			out[ i ] = ( float ) in[ i ];
 		return out;
@@ -104,7 +105,7 @@ public final class FloatConvolverRealType implements Runnable
 		out.fwd( d );
 	}
 
-	private void process( float w )
+	private void process( final float w )
 	{
 		for ( int i = 1; i < k1k; ++i )
 			buffer[ i ] = w * kernel[ i ] + buffer[ i + 1 ];

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
@@ -50,21 +50,21 @@ import net.imglib2.type.numeric.RealType;
 public final class FloatConvolverRealType implements Runnable
 {
 
-	final private float[] kernel;
+	private final float[] kernel;
 
-	final private RandomAccess< ? extends RealType< ? > > in;
+	private final RandomAccess< ? extends RealType< ? > > in;
 
-	final private RandomAccess< ? extends RealType< ? > > out;
+	private final RandomAccess< ? extends RealType< ? > > out;
 
-	final private int d;
+	private final int d;
 
-	final private int k1k1;
+	private final int k1k;
 
-	final private int k1k;
+	private final int k1k1;
 
-	final private long fill2;
+	private final long linelen;
 
-	final private float[] buffer;
+	private final float[] buffer;
 
 	public FloatConvolverRealType( final Kernel1D kernel, final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final int d, final long lineLength )
 	{
@@ -76,7 +76,7 @@ public final class FloatConvolverRealType implements Runnable
 
 		k1k = this.kernel.length;
 		k1k1 = k1k - 1;
-		fill2 = lineLength;
+		linelen = lineLength;
 		buffer = new float[ k1k + 1 ];
 	}
 
@@ -115,7 +115,7 @@ public final class FloatConvolverRealType implements Runnable
 	{
 		for ( int i = 0; i < k1k1; ++i )
 			prefill();
-		for ( long i = 0; i < fill2; ++i )
+		for ( long i = 0; i < linelen; ++i )
 			next();
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/FloatConvolverRealType.java
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * A 1-dimensional line convolver that operates on all {@link RealType}. It
+ * implemented using a shifting window buffer that is stored in a small double[]
+ * array.
+ *
+ * @author Tobias Pietzsch
+ * @author Matthias Arzt
+ * @see LineConvolverFactory
+ */
+public final class FloatConvolverRealType implements Runnable
+{
+
+	final private float[] kernel;
+
+	final private RandomAccess< ? extends RealType< ? > > in;
+
+	final private RandomAccess< ? extends RealType< ? > > out;
+
+	final private int d;
+
+	final private int k1k1;
+
+	final private int k1k;
+
+	final private long fill2;
+
+	final private float[] buffer;
+
+	public FloatConvolverRealType( final Kernel1D kernel, final RandomAccess< ? extends RealType< ? > > in, final RandomAccess< ? extends RealType< ? > > out, final int d, final long lineLength )
+	{
+		// NB: This constructor is used in ConvolverFactories. It needs to be public and have this exact signature.
+		this.in = in;
+		this.out = out;
+		this.d = d;
+		this.kernel = doubleToFloat( kernel.fullKernel() );
+
+		k1k = this.kernel.length;
+		k1k1 = k1k - 1;
+		fill2 = lineLength;
+		buffer = new float[ k1k + 1 ];
+	}
+
+	private float[] doubleToFloat( double[] in )
+	{
+		float[] out = new float[ in.length ];
+		for ( int i = 0; i < in.length; i++ )
+			out[ i ] = ( float ) in[ i ];
+		return out;
+	}
+
+	private void prefill()
+	{
+		final float w = in.get().getRealFloat();
+		process( w );
+		in.fwd( d );
+	}
+
+	private void next()
+	{
+		final float w = in.get().getRealFloat();
+		out.get().setReal( w * kernel[ 0 ] + buffer[ 1 ] );
+		process( w );
+		in.fwd( d );
+		out.fwd( d );
+	}
+
+	private void process( float w )
+	{
+		for ( int i = 1; i < k1k; ++i )
+			buffer[ i ] = w * kernel[ i ] + buffer[ i + 1 ];
+	}
+
+	@Override
+	public void run()
+	{
+		for ( int i = 0; i < k1k1; ++i )
+			prefill();
+		for ( long i = 0; i < fill2; ++i )
+			next();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
@@ -5,8 +5,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Kernel for a one dimensional convolution.
- * Multiple kernels could be used to specify a separable convolution.
+ * Kernel for a one dimensional convolution. Multiple kernels could be used to
+ * specify a separable convolution.
  *
  * @author Matthias Arzt
  */
@@ -20,22 +20,23 @@ public class Kernel1D
 	/**
 	 * Creates a one-dimensional symmetric convolution kernel.
 	 *
-	 * @param halfKernel the upper half (starting at the center pixel) of the symmetric
-	 *                   convolution kernel.
+	 * @param halfKernel
+	 *            the upper half (starting at the center pixel) of the symmetric
+	 *            convolution kernel.
 	 */
-	public static Kernel1D symmetric( double... halfKernel )
+	public static Kernel1D symmetric( final double... halfKernel )
 	{
 		Objects.requireNonNull( halfKernel );
 		return new Kernel1D(
 				halfToFullKernel( halfKernel ),
-				halfKernel.length - 1
-		);
+				halfKernel.length - 1 );
 	}
 
 	/**
-	 * Similar to {@link #symmetric(double[])} but creates an array of one-dimensional convolution kernels.
+	 * Similar to {@link #symmetric(double[])} but creates an array of
+	 * one-dimensional convolution kernels.
 	 */
-	public static Kernel1D[] symmetric( double[][] halfKernels )
+	public static Kernel1D[] symmetric( final double[][] halfKernels )
 	{
 		return Stream.of( halfKernels ).map( Kernel1D::symmetric ).toArray( Kernel1D[]::new );
 	}
@@ -43,46 +44,49 @@ public class Kernel1D
 	/**
 	 * Creates a one-dimensional asymmetric convolution kernel.
 	 *
-	 * @param fullKernel  an array containing the values of the kernel
-	 * @param originIndex the index of the array element which is the origin of the kernel
+	 * @param fullKernel
+	 *            an array containing the values of the kernel
+	 * @param originIndex
+	 *            the index of the array element which is the origin of the
+	 *            kernel
 	 */
-	public static Kernel1D asymmetric( double[] fullKernel, int originIndex )
+	public static Kernel1D asymmetric( final double[] fullKernel, final int originIndex )
 	{
 		Objects.requireNonNull( fullKernel );
 		return new Kernel1D(
 				fullKernel,
-				originIndex
-		);
+				originIndex );
 	}
 
 	/**
-	 * Creates a one-dimensional asymmetric convolution kernel,
-	 * where the origin of the kernel is in the middle.
+	 * Creates a one-dimensional asymmetric convolution kernel, where the origin
+	 * of the kernel is in the middle.
 	 */
-	public static Kernel1D centralAsymmetric( double... kernel )
+	public static Kernel1D centralAsymmetric( final double... kernel )
 	{
 		return asymmetric( kernel, ( kernel.length - 1 ) / 2 );
 	}
 
 	/**
-	 * Similar to {@link #asymmetric(double[], int)} but creates an array of one-dimensional convolution kernels.
+	 * Similar to {@link #asymmetric(double[], int)} but creates an array of
+	 * one-dimensional convolution kernels.
 	 */
-	public static Kernel1D[] asymmetric( double[][] fullKernels, int[] originIndices )
+	public static Kernel1D[] asymmetric( final double[][] fullKernels, final int[] originIndices )
 	{
 		return IntStream.range( 0, fullKernels.length ).mapToObj(
-				d -> asymmetric( fullKernels[ d ], originIndices[ d ] )
-		).toArray( Kernel1D[]::new );
+				d -> asymmetric( fullKernels[ d ], originIndices[ d ] ) ).toArray( Kernel1D[]::new );
 	}
 
 	/**
-	 * Similar to {@link #centralAsymmetric(double...)} but creates an array of one-dimensional convolution kernels.
+	 * Similar to {@link #centralAsymmetric(double...)} but creates an array of
+	 * one-dimensional convolution kernels.
 	 */
-	public static Kernel1D[] centralAsymmetric( double[][] kernels )
+	public static Kernel1D[] centralAsymmetric( final double[][] kernels )
 	{
 		return Stream.of( kernels ).map( Kernel1D::centralAsymmetric ).toArray( Kernel1D[]::new );
 	}
 
-	private Kernel1D( double[] fullKernel, int centralIndex )
+	private Kernel1D( final double[] fullKernel, final int centralIndex )
 	{
 		this.fullKernel = fullKernel;
 		this.centralIndex = centralIndex;
@@ -108,13 +112,13 @@ public class Kernel1D
 		return fullKernel().length;
 	}
 
-	// --  Helper methods --
+	// -- Helper methods --
 
-	public static double[] halfToFullKernel( double[] halfKernel )
+	public static double[] halfToFullKernel( final double[] halfKernel )
 	{
-		int k = halfKernel.length;
-		int k1 = k - 1;
-		double[] kernel = new double[ k1 + k ];
+		final int k = halfKernel.length;
+		final int k1 = k - 1;
+		final double[] kernel = new double[ k1 + k ];
 		for ( int i = 0; i < k; i++ )
 		{
 			kernel[ k1 - i ] = halfKernel[ i ];

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
@@ -1,0 +1,125 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import java.util.Objects;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Kernel for a one dimensional convolution.
+ * Multiple kernels could be used to specify a separable convolution.
+ *
+ * @author Matthias Arzt
+ */
+public class Kernel1D
+{
+
+	private final double[] fullKernel;
+
+	private final int centralIndex;
+
+	/**
+	 * Creates a one-dimensional symmetric convolution kernel.
+	 *
+	 * @param halfKernel the upper half (starting at the center pixel) of the symmetric
+	 *                   convolution kernel.
+	 */
+	public static Kernel1D symmetric( double... halfKernel )
+	{
+		Objects.requireNonNull( halfKernel );
+		return new Kernel1D(
+				halfToFullKernel( halfKernel ),
+				halfKernel.length - 1
+		);
+	}
+
+	/**
+	 * Similar to {@link #symmetric(double[])} but creates an array of one-dimensional convolution kernels.
+	 */
+	public static Kernel1D[] symmetric( double[][] halfKernels )
+	{
+		return Stream.of( halfKernels ).map( Kernel1D::symmetric ).toArray( Kernel1D[]::new );
+	}
+
+	/**
+	 * Creates a one-dimensional asymmetric convolution kernel.
+	 *
+	 * @param fullKernel  an array containing the values of the kernel
+	 * @param originIndex the index of the array element which is the origin of the kernel
+	 */
+	public static Kernel1D asymmetric( double[] fullKernel, int originIndex )
+	{
+		Objects.requireNonNull( fullKernel );
+		return new Kernel1D(
+				fullKernel,
+				originIndex
+		);
+	}
+
+	/**
+	 * Creates a one-dimensional asymmetric convolution kernel,
+	 * where the origin of the kernel is in the middle.
+	 */
+	public static Kernel1D centralAsymmetric( double... kernel )
+	{
+		return asymmetric( kernel, ( kernel.length - 1 ) / 2 );
+	}
+
+	/**
+	 * Similar to {@link #asymmetric(double[], int)} but creates an array of one-dimensional convolution kernels.
+	 */
+	public static Kernel1D[] asymmetric( double[][] fullKernels, int[] originIndices )
+	{
+		return IntStream.range( 0, fullKernels.length ).mapToObj(
+				d -> asymmetric( fullKernels[ d ], originIndices[ d ] )
+		).toArray( Kernel1D[]::new );
+	}
+
+	/**
+	 * Similar to {@link #centralAsymmetric(double...)} but creates an array of one-dimensional convolution kernels.
+	 */
+	public static Kernel1D[] centralAsymmetric( double[][] kernels )
+	{
+		return Stream.of( kernels ).map( Kernel1D::centralAsymmetric ).toArray( Kernel1D[]::new );
+	}
+
+	private Kernel1D( double[] fullKernel, int centralIndex )
+	{
+		this.fullKernel = fullKernel;
+		this.centralIndex = centralIndex;
+	}
+
+	public double[] fullKernel()
+	{
+		return fullKernel;
+	}
+
+	public long min()
+	{
+		return -centralIndex;
+	}
+
+	public long max()
+	{
+		return size() - 1 - centralIndex;
+	}
+
+	public int size()
+	{
+		return fullKernel().length;
+	}
+
+	// --  Helper methods --
+
+	public static double[] halfToFullKernel( double[] halfKernel )
+	{
+		int k = halfKernel.length;
+		int k1 = k - 1;
+		double[] kernel = new double[ k1 + k ];
+		for ( int i = 0; i < k; i++ )
+		{
+			kernel[ k1 - i ] = halfKernel[ i ];
+			kernel[ k1 + i ] = halfKernel[ i ];
+		}
+		return kernel;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
@@ -1,0 +1,99 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.loops.ClassCopyProvider;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Used by {@link SeparableKernelConvolution} as {@link LineConvolverFactory}
+ * for convolution. {@link ClassCopyProvider} is used to create copies
+ * of the byte code of the actual convolvers. This improves their performance,
+ * as the JIT can optimize the byte code to the individual use cases.
+ * <p>
+ * The actual convolvers that are used (depending on the pixel type) are:
+ * {@link DoubleConvolverRealType}, {@link FloatConvolverRealType},
+ * {@link ConvolverNativeType}, {@link ConvolverNumericType}.
+ *
+ * @author Matthias Arzt
+ */
+public class KernelConvolverFactory implements LineConvolverFactory< NumericType< ? > >
+{
+
+	private final Kernel1D kernel;
+
+	public KernelConvolverFactory( Kernel1D kernel )
+	{
+		this.kernel = kernel;
+	}
+
+	@Override public long getBorderBefore()
+	{
+		return +kernel.max();
+	}
+
+	@Override public long getBorderAfter()
+	{
+		return -kernel.min();
+	}
+
+	@Override public Runnable getConvolver( RandomAccess< ? extends NumericType< ? > > in, RandomAccess< ? extends NumericType< ? > > out, int d, long lineLength )
+	{
+		NumericType< ? > targetType = out.get();
+		NumericType< ? > sourceType = in.get();
+		ClassCopyProvider< Runnable > provider = getProvider( sourceType, targetType );
+		List< Class< ? > > key = Arrays.asList( in.getClass(), out.getClass(), sourceType.getClass(), targetType.getClass() );
+		return provider.newInstanceForKey( key, kernel, in, out, d, lineLength );
+	}
+
+	private ClassCopyProvider< Runnable > getProvider( NumericType< ? > sourceType, NumericType< ? > targetType )
+	{
+		for ( Entry entry : factories )
+			if ( entry.supported( sourceType, targetType ) )
+				return entry.provider;
+		throw new IllegalArgumentException( "Convolution is not supported for the given source and target type," +
+				" source: " + sourceType.getClass().getSimpleName() +
+				" target: " + targetType.getClass().getSimpleName() );
+	}
+
+	private static final List< Entry > factories = Arrays.asList(
+			new Entry( DoubleConvolverRealType.class, RealType.class, DoubleType.class ),
+			new Entry( FloatConvolverRealType.class, RealType.class, RealType.class ),
+			new Entry( ConvolverNativeType.class, null, NativeType.class ),
+			new Entry( ConvolverNumericType.class, null, NumericType.class )
+	);
+
+	private static class Entry
+	{
+
+		private final ClassCopyProvider< Runnable > provider;
+
+		private final Class< ? extends Type > sourceClass;
+
+		private final Class< ? extends Type > targetClass;
+
+		private Entry( Class< ? extends Runnable > convolverClass, Class< ? extends Type > sourceClass, Class< ? extends Type > targetClass )
+		{
+			this.provider = new ClassCopyProvider<>( convolverClass, Runnable.class );
+			this.sourceClass = sourceClass;
+			this.targetClass = targetClass;
+		}
+
+		private boolean supported( Object sourceType, Type< ? > targetType )
+		{
+			if ( !targetClass.isInstance( targetType ) )
+				return false;
+			Class< ? > sourceClass = this.sourceClass == null ?
+					targetType.getClass() : this.sourceClass;
+			return sourceClass.isInstance( sourceType );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
@@ -11,6 +11,7 @@ import net.imglib2.type.Type;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 /**
  * Used by {@link SeparableKernelConvolution} as {@link LineConvolverFactory}
@@ -54,6 +55,16 @@ public class KernelConvolverFactory implements LineConvolverFactory< NumericType
 		final ClassCopyProvider< Runnable > provider = getProvider( sourceType, targetType );
 		final List< Class< ? > > key = Arrays.asList( in.getClass(), out.getClass(), sourceType.getClass(), targetType.getClass() );
 		return provider.newInstanceForKey( key, kernel, in, out, d, lineLength );
+	}
+
+	@Override
+	public NumericType< ? > preferredSourceType( NumericType< ? > targetType )
+	{
+		if (targetType instanceof DoubleType)
+			return targetType;
+		if (targetType instanceof RealType)
+			return new FloatType();
+		return targetType;
 	}
 
 	private ClassCopyProvider< Runnable > getProvider( final NumericType< ? > sourceType, final NumericType< ? > targetType )

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactory.java
@@ -1,8 +1,10 @@
 package net.imglib2.algorithm.convolution.kernel;
 
+import java.util.Arrays;
+import java.util.List;
+
 import net.imglib2.RandomAccess;
 import net.imglib2.algorithm.convolution.LineConvolverFactory;
-import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.loops.ClassCopyProvider;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
@@ -10,14 +12,11 @@ import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * Used by {@link SeparableKernelConvolution} as {@link LineConvolverFactory}
- * for convolution. {@link ClassCopyProvider} is used to create copies
- * of the byte code of the actual convolvers. This improves their performance,
- * as the JIT can optimize the byte code to the individual use cases.
+ * for convolution. {@link ClassCopyProvider} is used to create copies of the
+ * byte code of the actual convolvers. This improves their performance, as the
+ * JIT can optimize the byte code to the individual use cases.
  * <p>
  * The actual convolvers that are used (depending on the pixel type) are:
  * {@link DoubleConvolverRealType}, {@link FloatConvolverRealType},
@@ -30,33 +29,36 @@ public class KernelConvolverFactory implements LineConvolverFactory< NumericType
 
 	private final Kernel1D kernel;
 
-	public KernelConvolverFactory( Kernel1D kernel )
+	public KernelConvolverFactory( final Kernel1D kernel )
 	{
 		this.kernel = kernel;
 	}
 
-	@Override public long getBorderBefore()
+	@Override
+	public long getBorderBefore()
 	{
 		return +kernel.max();
 	}
 
-	@Override public long getBorderAfter()
+	@Override
+	public long getBorderAfter()
 	{
 		return -kernel.min();
 	}
 
-	@Override public Runnable getConvolver( RandomAccess< ? extends NumericType< ? > > in, RandomAccess< ? extends NumericType< ? > > out, int d, long lineLength )
+	@Override
+	public Runnable getConvolver( final RandomAccess< ? extends NumericType< ? > > in, final RandomAccess< ? extends NumericType< ? > > out, final int d, final long lineLength )
 	{
-		NumericType< ? > targetType = out.get();
-		NumericType< ? > sourceType = in.get();
-		ClassCopyProvider< Runnable > provider = getProvider( sourceType, targetType );
-		List< Class< ? > > key = Arrays.asList( in.getClass(), out.getClass(), sourceType.getClass(), targetType.getClass() );
+		final NumericType< ? > targetType = out.get();
+		final NumericType< ? > sourceType = in.get();
+		final ClassCopyProvider< Runnable > provider = getProvider( sourceType, targetType );
+		final List< Class< ? > > key = Arrays.asList( in.getClass(), out.getClass(), sourceType.getClass(), targetType.getClass() );
 		return provider.newInstanceForKey( key, kernel, in, out, d, lineLength );
 	}
 
-	private ClassCopyProvider< Runnable > getProvider( NumericType< ? > sourceType, NumericType< ? > targetType )
+	private ClassCopyProvider< Runnable > getProvider( final NumericType< ? > sourceType, final NumericType< ? > targetType )
 	{
-		for ( Entry entry : factories )
+		for ( final Entry entry : factories )
 			if ( entry.supported( sourceType, targetType ) )
 				return entry.provider;
 		throw new IllegalArgumentException( "Convolution is not supported for the given source and target type," +
@@ -68,8 +70,7 @@ public class KernelConvolverFactory implements LineConvolverFactory< NumericType
 			new Entry( DoubleConvolverRealType.class, RealType.class, DoubleType.class ),
 			new Entry( FloatConvolverRealType.class, RealType.class, RealType.class ),
 			new Entry( ConvolverNativeType.class, null, NativeType.class ),
-			new Entry( ConvolverNumericType.class, null, NumericType.class )
-	);
+			new Entry( ConvolverNumericType.class, null, NumericType.class ) );
 
 	private static class Entry
 	{
@@ -80,19 +81,18 @@ public class KernelConvolverFactory implements LineConvolverFactory< NumericType
 
 		private final Class< ? extends Type > targetClass;
 
-		private Entry( Class< ? extends Runnable > convolverClass, Class< ? extends Type > sourceClass, Class< ? extends Type > targetClass )
+		private Entry( final Class< ? extends Runnable > convolverClass, final Class< ? extends Type > sourceClass, final Class< ? extends Type > targetClass )
 		{
 			this.provider = new ClassCopyProvider<>( convolverClass, Runnable.class );
 			this.sourceClass = sourceClass;
 			this.targetClass = targetClass;
 		}
 
-		private boolean supported( Object sourceType, Type< ? > targetType )
+		private boolean supported( final Object sourceType, final Type< ? > targetType )
 		{
 			if ( !targetClass.isInstance( targetType ) )
 				return false;
-			Class< ? > sourceClass = this.sourceClass == null ?
-					targetType.getClass() : this.sourceClass;
+			final Class< ? > sourceClass = this.sourceClass == null ? targetType.getClass() : this.sourceClass;
 			return sourceClass.isInstance( sourceType );
 		}
 	}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
@@ -1,0 +1,87 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.convolution.Convolution;
+import net.imglib2.algorithm.convolution.LineConvolution;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Convolution with a customizable separable kernel.
+ *
+ * @author Matthias Arzt
+ */
+public class SeparableKernelConvolution
+{
+	/**
+	 * Return an object, that performs the separable convolution with the given kernel.
+	 * It additionally allows to set the {@link java.util.concurrent.ExecutorService} to use
+	 * or to query for the required input image size, ...
+	 * <p>
+	 * A small example how it works:
+	 * <pre>
+	 * {@code
+	 * double[][] values = { { 1, 2, 1 }, { -1, 0, 1 } }; int[] center = { 1, 1 };
+	 * Kernel1D[] sobelKernel = Kernel1D.asymmetric( values, center );
+	 * SeparableKernelConvolution.convolution( sobelKernel ).process( Views.extendBorder( inputImage ), outputImage );
+	 * }
+	 * </pre>
+	 *
+	 * @see Convolution
+	 */
+	public static Convolution< NumericType< ? > > convolution( Kernel1D[] kernels )
+	{
+		List< Convolution< NumericType< ? > > > steps = IntStream.range( 0, kernels.length )
+				.mapToObj( i -> convolution1d( kernels[ i ], i ) )
+				.collect( Collectors.toList() );
+		return Convolution.concat( steps );
+	}
+
+	/**
+	 * Apply a convolution only in one dimension. For example calculate central differences:
+	 * <pre>
+	 * {@code
+	 * double[] values = { -0.5, 0, 0.5 }; int center = 1;
+	 * Kernel1D[] sobelKernel = Kernel1D.asymmetric( values, center );
+	 * SeparableKernelConvolution.convolution1d( sobelKernel, 0 ).process( Views.extendBorder( inputImage ), outputImage );
+	 * }
+	 * </pre>
+	 *
+	 * @see Convolution
+	 */
+	public static Convolution< NumericType< ? > > convolution1d( Kernel1D kernel, int direction )
+	{
+		return new LineConvolution<>( new KernelConvolverFactory( kernel ), direction );
+	}
+
+	/**
+	 * Convolve source with a separable kernel and write the result to
+	 * output. In-place operation (source==target) is supported.
+	 * <p>
+	 * <p>
+	 * If the target type T is {@link DoubleType}, all calculations are done in
+	 * double precision. For all other target {@link RealType RealTypes} float
+	 * precision is used. General {@link NumericType NumericTypes} are computed
+	 * in their own precision. The source type S and target type T are either
+	 * both {@link RealType RealTypes} or both the same type.
+	 *
+	 * @param kernels an array containing kernels for every dimension.
+	 * @param source  source image, must be sufficiently padded (use e.g.
+	 *                {@link Views#extendMirrorSingle(RandomAccessibleInterval)})
+	 *                the required source interval.
+	 * @param target  target image.
+	 */
+	public static void convolve( Kernel1D[] kernels,
+			RandomAccessible< ? extends NumericType< ? > > source,
+			RandomAccessibleInterval< ? extends NumericType< ? > > target )
+	{
+		convolution( kernels ).process( source, target );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
@@ -37,7 +37,7 @@ public class SeparableKernelConvolution
 	 *
 	 * @see Convolution
 	 */
-	public static Convolution< NumericType< ? > > convolution( final Kernel1D[] kernels )
+	public static Convolution< NumericType< ? > > convolution( final Kernel1D... kernels )
 	{
 		final List< Convolution< NumericType< ? > > > steps = IntStream.range( 0, kernels.length )
 				.mapToObj( i -> convolution1d( kernels[ i ], i ) )

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
@@ -1,5 +1,9 @@
 package net.imglib2.algorithm.convolution.kernel;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.convolution.Convolution;
@@ -9,10 +13,6 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 /**
  * Convolution with a customizable separable kernel.
  *
@@ -21,9 +21,10 @@ import java.util.stream.IntStream;
 public class SeparableKernelConvolution
 {
 	/**
-	 * Return an object, that performs the separable convolution with the given kernel.
-	 * It additionally allows to set the {@link java.util.concurrent.ExecutorService} to use
-	 * or to query for the required input image size, ...
+	 * Return an object, that performs the separable convolution with the given
+	 * kernel. It additionally allows to set the
+	 * {@link java.util.concurrent.ExecutorService} to use or to query for the
+	 * required input image size, ...
 	 * <p>
 	 * A small example how it works:
 	 * <pre>
@@ -36,16 +37,17 @@ public class SeparableKernelConvolution
 	 *
 	 * @see Convolution
 	 */
-	public static Convolution< NumericType< ? > > convolution( Kernel1D[] kernels )
+	public static Convolution< NumericType< ? > > convolution( final Kernel1D[] kernels )
 	{
-		List< Convolution< NumericType< ? > > > steps = IntStream.range( 0, kernels.length )
+		final List< Convolution< NumericType< ? > > > steps = IntStream.range( 0, kernels.length )
 				.mapToObj( i -> convolution1d( kernels[ i ], i ) )
 				.collect( Collectors.toList() );
 		return Convolution.concat( steps );
 	}
 
 	/**
-	 * Apply a convolution only in one dimension. For example calculate central differences:
+	 * Apply a convolution only in one dimension. For example calculate central
+	 * differences:
 	 * <pre>
 	 * {@code
 	 * double[] values = { -0.5, 0, 0.5 }; int center = 1;
@@ -56,15 +58,14 @@ public class SeparableKernelConvolution
 	 *
 	 * @see Convolution
 	 */
-	public static Convolution< NumericType< ? > > convolution1d( Kernel1D kernel, int direction )
+	public static Convolution< NumericType< ? > > convolution1d( final Kernel1D kernel, final int direction )
 	{
 		return new LineConvolution<>( new KernelConvolverFactory( kernel ), direction );
 	}
 
 	/**
-	 * Convolve source with a separable kernel and write the result to
-	 * output. In-place operation (source==target) is supported.
-	 * <p>
+	 * Convolve source with a separable kernel and write the result to output.
+	 * In-place operation (source==target) is supported.
 	 * <p>
 	 * If the target type T is {@link DoubleType}, all calculations are done in
 	 * double precision. For all other target {@link RealType RealTypes} float
@@ -72,15 +73,18 @@ public class SeparableKernelConvolution
 	 * in their own precision. The source type S and target type T are either
 	 * both {@link RealType RealTypes} or both the same type.
 	 *
-	 * @param kernels an array containing kernels for every dimension.
-	 * @param source  source image, must be sufficiently padded (use e.g.
-	 *                {@link Views#extendMirrorSingle(RandomAccessibleInterval)})
-	 *                the required source interval.
-	 * @param target  target image.
+	 * @param kernels
+	 *            an array containing kernels for every dimension.
+	 * @param source
+	 *            source image, must be sufficiently padded (use e.g.
+	 *            {@link Views#extendMirrorSingle(RandomAccessibleInterval)})
+	 *            the required source interval.
+	 * @param target
+	 *            target image.
 	 */
-	public static void convolve( Kernel1D[] kernels,
-			RandomAccessible< ? extends NumericType< ? > > source,
-			RandomAccessibleInterval< ? extends NumericType< ? > > target )
+	public static void convolve( final Kernel1D[] kernels,
+			final RandomAccessible< ? extends NumericType< ? > > source,
+			final RandomAccessibleInterval< ? extends NumericType< ? > > target )
 	{
 		convolution( kernels ).process( source, target );
 	}

--- a/src/main/java/net/imglib2/algorithm/gauss3/ConvolverFactory.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/ConvolverFactory.java
@@ -45,6 +45,7 @@ import net.imglib2.RandomAccess;
  * @param <S>
  * @param <T>
  */
+@Deprecated
 public interface ConvolverFactory< S, T >
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNativeType.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNativeType.java
@@ -54,6 +54,7 @@ import net.imglib2.type.numeric.NumericType;
  * @param <T>
  *            input and output type
  */
+@Deprecated
 public final class ConvolverNativeType< T extends NumericType< T > & NativeType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNativeTypeBuffered.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNativeTypeBuffered.java
@@ -54,6 +54,7 @@ import net.imglib2.type.numeric.NumericType;
  * @param <T>
  *            input and output type
  */
+@Deprecated
 public final class ConvolverNativeTypeBuffered< T extends NumericType< T > & NativeType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNumericType.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/ConvolverNumericType.java
@@ -49,6 +49,7 @@ import net.imglib2.type.numeric.NumericType;
  * @param <T>
  *            input and output type
  */
+@Deprecated
 public class ConvolverNumericType< T extends NumericType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/DoubleConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/DoubleConvolverRealType.java
@@ -52,6 +52,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  *            output type
  */
+@Deprecated
 public final class DoubleConvolverRealType< S extends RealType< S >, T extends RealType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/DoubleConvolverRealTypeBuffered.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/DoubleConvolverRealTypeBuffered.java
@@ -52,6 +52,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  *            output type
  */
+@Deprecated
 public final class DoubleConvolverRealTypeBuffered< S extends RealType< S >, T extends RealType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/FloatConvolverRealType.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/FloatConvolverRealType.java
@@ -52,6 +52,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  *            output type
  */
+@Deprecated
 public final class FloatConvolverRealType< S extends RealType< S >, T extends RealType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/FloatConvolverRealTypeBuffered.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/FloatConvolverRealTypeBuffered.java
@@ -52,6 +52,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  *            output type
  */
+@Deprecated
 public final class FloatConvolverRealTypeBuffered< S extends RealType< S >, T extends RealType< T > > implements Runnable
 {
 	/**

--- a/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
@@ -202,7 +202,7 @@ public final class Gauss3
 	public static < S extends NumericType< S >, T extends NumericType< T > > void gauss( final double[] sigma, final RandomAccessible< S > source, final RandomAccessibleInterval< T > target, final ExecutorService service ) throws IncompatibleTypeException
 	{
 		final double[][] halfkernels = halfkernels( sigma );
-		Convolution< NumericType< ? > > convolution = SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfkernels ) );
+		final Convolution< NumericType< ? > > convolution = SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfkernels ) );
 		convolution.setExecutor( service );
 		convolution.process( source, target );
 	}

--- a/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
@@ -39,6 +39,9 @@ import java.util.concurrent.Executors;
 
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.convolution.Convolution;
+import net.imglib2.algorithm.convolution.kernel.Kernel1D;
+import net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
@@ -161,9 +164,8 @@ public final class Gauss3
 	 */
 	public static < S extends NumericType< S >, T extends NumericType< T > > void gauss( final double[] sigma, final RandomAccessible< S > source, final RandomAccessibleInterval< T > target, final int numThreads ) throws IncompatibleTypeException
 	{
-		final double[][] halfkernels = halfkernels( sigma );
 		final ExecutorService service = Executors.newFixedThreadPool( numThreads );
-		SeparableSymmetricConvolution.convolve( halfkernels, source, target, service );
+		gauss( sigma, source, target, service );
 		service.shutdown();
 	}
 
@@ -200,7 +202,9 @@ public final class Gauss3
 	public static < S extends NumericType< S >, T extends NumericType< T > > void gauss( final double[] sigma, final RandomAccessible< S > source, final RandomAccessibleInterval< T > target, final ExecutorService service ) throws IncompatibleTypeException
 	{
 		final double[][] halfkernels = halfkernels( sigma );
-		SeparableSymmetricConvolution.convolve( halfkernels, source, target, service );
+		Convolution< NumericType< ? > > convolution = SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfkernels ) );
+		convolution.setExecutor( service );
+		convolution.process( source, target );
 	}
 
 	public static double[][] halfkernels( final double[] sigma )

--- a/src/main/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolution.java
@@ -35,7 +35,6 @@
 package net.imglib2.algorithm.gauss3;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -47,8 +46,6 @@ import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.convolution.Convolution;
-import net.imglib2.algorithm.convolution.LineConvolverFactory;
 import net.imglib2.algorithm.convolution.kernel.Kernel1D;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;

--- a/src/main/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolution.java
@@ -35,6 +35,7 @@
 package net.imglib2.algorithm.gauss3;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +47,9 @@ import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.convolution.Convolution;
+import net.imglib2.algorithm.convolution.LineConvolverFactory;
+import net.imglib2.algorithm.convolution.kernel.Kernel1D;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
@@ -62,13 +66,17 @@ import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
 /**
+ * @deprecated Use {@link net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution} instead.
  * Convolution with a separable symmetric kernel.
  * 
  * @author Tobias Pietzsch
  */
+@Deprecated
 public final class SeparableSymmetricConvolution
 {
 	/**
+	 * @deprecated Use {@link net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution#convolution(Kernel1D[])}
+	 * <p>
 	 * Convolve source with a separable symmetric kernel and write the result to
 	 * output. In-place operation (source==target) is supported.
 	 * 
@@ -100,6 +108,7 @@ public final class SeparableSymmetricConvolution
 	 *             if source and target type are not compatible (they must be
 	 *             either both {@link RealType RealTypes} or the same type).
 	 */
+	@Deprecated
 	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	public static < S extends NumericType< S >, T extends NumericType< T > > void convolve( final double[][] halfkernels, final RandomAccessible< S > source, final RandomAccessibleInterval< T > target, final ExecutorService service ) throws IncompatibleTypeException
 	{
@@ -203,6 +212,10 @@ public final class SeparableSymmetricConvolution
 		return a.get();
 	}
 
+	/**
+	 * @deprecated Use {@link net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution#convolution1d}
+	 */
+	@Deprecated
 	public static < S, T > void convolve1d( final double[] halfkernel,
 			final RandomAccessible< S > source, final RandomAccessibleInterval< T > target,
 			final ConvolverFactory< S, T > convolverFactoryST,
@@ -213,6 +226,10 @@ public final class SeparableSymmetricConvolution
 	}
 
 	/**
+	 * @deprecated
+	 * Use {@link net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution#convolution(Kernel1D[])}.
+	 * Or {@link net.imglib2.algorithm.convolution.LineConvolution} and {@link net.imglib2.algorithm.convolution.Convolution#concat}.
+	 * <p>
 	 * Convolve source with a separable symmetric kernel and write the result to
 	 * output. In-place operation (source==target) is supported. Calculations
 	 * are done in the intermediate type determined by the
@@ -246,6 +263,7 @@ public final class SeparableSymmetricConvolution
 	 * @param service
 	 *            service providing threads for multi-threading
 	 */
+	@Deprecated
 	public static < S, I, T > void convolve( final double[][] halfkernels,
 			final RandomAccessible< S > source, final RandomAccessibleInterval< T > target,
 			final ConvolverFactory< S, I > convolverFactorySI,

--- a/src/test/java/net/imglib2/algorithm/convolution/ConcatenationTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/ConcatenationTest.java
@@ -1,0 +1,114 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.ConstantUtils;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConcatenationTest
+{
+	@Test
+	public void testDifferences()
+	{
+		Img< DoubleType > source = ArrayImgs.doubles( new double[] {
+				0, 0, 0,
+				0, 1, 0,
+				0, 0, 0
+		}, 3, 3 );
+		ForwardDifference stepX = new ForwardDifference( 0 );
+		ForwardDifference stepY = new ForwardDifference( 1 );
+		Convolution< RealType< ? > > convolution = Convolution.concat( stepX, stepY );
+		double[] targetPixels = new double[ 4 ];
+		Img< DoubleType > target = ArrayImgs.doubles( targetPixels, 2, 2 );
+		assertTrue( Intervals.equals( source, convolution.requiredSourceInterval( target ) ) );
+		convolution.process( source, target );
+		assertArrayEquals( new double[] { 1, -1, -1, 1 }, targetPixels, 0.0 );
+	}
+
+	@Test
+	public void testDifferences2()
+	{
+		Img< IntType > source = ArrayImgs.ints( new int[] { 0, 0, 1, 0, 0 }, 5 );
+		ForwardDifference step = new ForwardDifference( 0 );
+		Convolution< RealType< ? > > convolution = Convolution.concat( step, step, step );
+		int[] targetPixels = new int[ 2 ];
+		Img< IntType > target = ArrayImgs.ints( targetPixels, 2 );
+		convolution.process( source, target );
+		assertArrayEquals( new int[] { -3, 3 }, targetPixels );
+	}
+
+	@Test
+	public void testHugeImage()
+	{
+		long width = 0x10000;
+		long height = 0x10000;
+		assertTrue( width * height > Integer.MAX_VALUE );
+		RandomAccessible< UnsignedByteType > source = ConstantUtils.constantRandomAccessible( new UnsignedByteType(), 2 );
+		RandomAccessibleInterval< UnsignedByteType > target = ConstantUtils.constantRandomAccessibleInterval(
+				new UnsignedByteType(), 2, new FinalInterval( width, height ) );
+		double[][] kernels = { { 2 }, { 3 } };
+		try
+		{
+			Convolution.concat( new ForwardDifference( 0 ), new ForwardDifference( 1 ) )
+					.process( source, target );
+		}
+		catch ( OutOfMemoryError acceptable )
+		{
+			// NB: It's ok if we run out of memory here. It still means CellImgFactory was used for the temporary image.
+		}
+	}
+
+	private static class ForwardDifference implements Convolution< RealType< ? > >
+	{
+
+		private final int d;
+
+		private ForwardDifference( int d )
+		{
+			this.d = d;
+		}
+
+		@Override
+		public Interval requiredSourceInterval( Interval targetInterval )
+		{
+			long[] min = Intervals.minAsLongArray( targetInterval );
+			long[] max = Intervals.maxAsLongArray( targetInterval );
+			max[ d ]++;
+			return new FinalInterval( min, max );
+		}
+
+		@Override
+		public RealType< ? > preferredSourceType( RealType< ? > targetType )
+		{
+			return targetType;
+		}
+
+		@Override
+		public void process( RandomAccessible< ? extends RealType< ? > > source, RandomAccessibleInterval< ? extends RealType< ? > > target )
+		{
+			IntervalView< ? extends RealType< ? > > back = Views.interval( source, target );
+			IntervalView< ? extends RealType< ? > > front = Views.interval( source, Intervals.translate( target, 1, d ) );
+			LoopBuilder.setImages( back, front, target ).forEachPixel( ( b, f, r ) ->
+					r.setReal( f.getRealDouble() - b.getRealDouble() )
+			);
+		}
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
@@ -83,7 +83,7 @@ public class ConvolverBenchmark
 	}
 
 	@Benchmark
-	public void asymmetricNumericConvolve()
+	public void asymmetricNumericConvolver()
 	{
 		final Runnable runnable = new ConvolverNumericType<>( kernel, in(), out(), d, lineLength );
 		runnable.run();

--- a/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
@@ -2,6 +2,7 @@ package net.imglib2.algorithm.convolution;
 
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.convolution.fast_gauss.FastGaussConvolverRealType;
 import net.imglib2.algorithm.convolution.kernel.Kernel1D;
 import net.imglib2.algorithm.convolution.kernel.KernelConvolverFactory;
 import net.imglib2.algorithm.gauss3.DoubleConvolverRealType;
@@ -50,6 +51,14 @@ public class ConvolverBenchmark
 	public void symmetricKernelConvolver()
 	{
 		Runnable runnable = DoubleConvolverRealType.< DoubleType, DoubleType >factory().create( halfKernel, in(), out(), d, lineLength );
+		runnable.run();
+	}
+
+	@Benchmark
+	public void fastGaussConvolver()
+	{
+		Runnable runnable = new FastGaussConvolverRealType( sigma )
+				.getConvolver( in(), out(), d, lineLength );
 		runnable.run();
 	}
 

--- a/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
@@ -111,7 +111,7 @@ public class ConvolverBenchmark
 	{
 		Options opt = new OptionsBuilder()
 				.include( ConvolverBenchmark.class.getSimpleName() )
-				.forks( 0 )
+				.forks( 1 )
 				.warmupIterations( 8 )
 				.measurementIterations( 8 )
 				.warmupTime( TimeValue.milliseconds( 100 ) )

--- a/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/ConvolverBenchmark.java
@@ -1,0 +1,78 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.convolution.kernel.Kernel1D;
+import net.imglib2.algorithm.convolution.kernel.KernelConvolverFactory;
+import net.imglib2.algorithm.gauss3.DoubleConvolverRealType;
+import net.imglib2.algorithm.gauss3.Gauss3;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State( Scope.Benchmark )
+public class ConvolverBenchmark
+{
+
+	private int d = 2;
+
+	private long lineLength = 1000;
+
+	private double sigma = 2.0;
+
+	private long[] dims = { 10, 10, lineLength };
+
+	RandomAccessible< DoubleType > inImage = Views.extendBorder( ArrayImgs.doubles( dims ) );
+
+	Img< DoubleType > outImage = ArrayImgs.doubles( dims );
+
+	double[] halfKernel = Gauss3.halfkernels( new double[] { sigma } )[ 0 ];
+
+	@Benchmark
+	public void asymmetricKernelConvolver()
+	{
+		LineConvolverFactory< NumericType< ? > > assymetricConvolver = new KernelConvolverFactory( Kernel1D.symmetric( halfKernel ) );
+		Runnable runnable = assymetricConvolver.getConvolver( in(), out(), d, lineLength );
+		runnable.run();
+	}
+
+	@Benchmark
+	public void symmetricKernelConvolver()
+	{
+		Runnable runnable = DoubleConvolverRealType.< DoubleType, DoubleType >factory().create( halfKernel, in(), out(), d, lineLength );
+		runnable.run();
+	}
+
+	private RandomAccess< DoubleType > in()
+	{
+		return inImage.randomAccess();
+	}
+
+	private RandomAccess< DoubleType > out()
+	{
+		return outImage.randomAccess();
+	}
+
+	public static void main( String[] args ) throws RunnerException
+	{
+		Options opt = new OptionsBuilder()
+				.include( ConvolverBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
@@ -8,6 +8,8 @@ import net.imglib2.algorithm.gauss3.Gauss3;
 import net.imglib2.algorithm.gauss3.SeparableSymmetricConvolution;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -54,14 +56,14 @@ public class GaussBenchmark
 	@Benchmark
 	public void benchmarkFastGauss()
 	{
-		FastGauss.convolve( sigma, inImage, outImage );
+		FastGauss.convolution( sigma ).process( inImage, outImage );
 	}
 
 	public static void main( String[] args ) throws RunnerException
 	{
 		Options opt = new OptionsBuilder()
 				.include( GaussBenchmark.class.getSimpleName() )
-				.forks( 0 )
+				.forks( 1 )
 				.warmupIterations( 4 )
 				.measurementIterations( 8 )
 				.warmupTime( TimeValue.milliseconds( 100 ) )

--- a/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
@@ -44,7 +44,7 @@ public class GaussBenchmark
 	}
 
 	@Benchmark
-	public void benchmarkSeparableSymmertricConvolution()
+	public void benchmarkSeparableSymmetricConvolution()
 	{
 		double[][] halfKernels = Gauss3.halfkernels( new double[] { sigma, sigma, sigma } );
 		final int numthreads = Runtime.getRuntime().availableProcessors();

--- a/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
@@ -40,7 +40,12 @@ public class GaussBenchmark
 	public void benchmarkSeparableKernelConvolution()
 	{
 		double[][] halfKernels = Gauss3.halfkernels( new double[] { sigma, sigma, sigma } );
-		SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfKernels ) ).process( inImage, outImage );
+		final int numthreads = Runtime.getRuntime().availableProcessors();
+		final ExecutorService service = Executors.newFixedThreadPool( numthreads );
+		final Convolution< NumericType< ? > > convolution = SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfKernels ) );
+		convolution.setExecutor( service );
+		convolution.process( inImage, outImage );
+		service.shutdown();
 	}
 
 	@Benchmark

--- a/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
@@ -64,7 +64,7 @@ public class GaussBenchmark
 		Options opt = new OptionsBuilder()
 				.include( GaussBenchmark.class.getSimpleName() )
 				.forks( 1 )
-				.warmupIterations( 4 )
+				.warmupIterations( 8 )
 				.measurementIterations( 8 )
 				.warmupTime( TimeValue.milliseconds( 100 ) )
 				.measurementTime( TimeValue.milliseconds( 100 ) )

--- a/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/GaussBenchmark.java
@@ -1,0 +1,72 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.convolution.fast_gauss.FastGauss;
+import net.imglib2.algorithm.convolution.kernel.Kernel1D;
+import net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution;
+import net.imglib2.algorithm.gauss3.Gauss3;
+import net.imglib2.algorithm.gauss3.SeparableSymmetricConvolution;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@State( Scope.Benchmark )
+public class GaussBenchmark
+{
+
+	private double sigma = 2.0;
+
+	private long[] dims = { 200, 200, 200 };
+
+	private RandomAccessible< DoubleType > inImage = Views.extendBorder( ArrayImgs.doubles( dims ) );
+
+	private Img< DoubleType > outImage = ArrayImgs.doubles( dims );
+
+	@Benchmark
+	public void benchmarkSeparableKernelConvolution()
+	{
+		double[][] halfKernels = Gauss3.halfkernels( new double[] { sigma, sigma, sigma } );
+		SeparableKernelConvolution.convolution( Kernel1D.symmetric( halfKernels ) ).process( inImage, outImage );
+	}
+
+	@Benchmark
+	public void benchmarkSeparableSymmertricConvolution()
+	{
+		double[][] halfKernels = Gauss3.halfkernels( new double[] { sigma, sigma, sigma } );
+		final int numthreads = Runtime.getRuntime().availableProcessors();
+		final ExecutorService service = Executors.newFixedThreadPool( numthreads );
+		SeparableSymmetricConvolution.convolve( halfKernels, inImage, outImage, service );
+		service.shutdown();
+	}
+
+	@Benchmark
+	public void benchmarkFastGauss()
+	{
+		FastGauss.convolve( sigma, inImage, outImage );
+	}
+
+	public static void main( String[] args ) throws RunnerException
+	{
+		Options opt = new OptionsBuilder()
+				.include( GaussBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
@@ -1,0 +1,75 @@
+package net.imglib2.algorithm.convolution;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LineConvolutionTest
+{
+
+	@Test
+	public void testConvolveOneLine()
+	{
+		byte[] result = new byte[ 3 ];
+		Img< UnsignedByteType > out = ArrayImgs.unsignedBytes( result, result.length );
+		Img< UnsignedByteType > in = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 0, 3 }, 4 );
+		new LineConvolution<>( new ForwardDifferenceConvolverFactory(), 0 ).process( in, out );
+		assertArrayEquals( new byte[] { 1, -2, 3 }, result );
+	}
+
+	@Test
+	public void testConvolve()
+	{
+		Img< UnsignedByteType > source = ArrayImgs.unsignedBytes( new byte[] {
+				0, 0, 0, 1,
+				3, 4, 5, 0,
+				0, 0, 0, 3
+		}, 2, 2, 3 );
+		byte[] result = new byte[ 8 ];
+		byte[] expected = new byte[] {
+				3, 4, 5, -1,
+				-3, -4, -5, 3
+		};
+		Img< UnsignedByteType > target = ArrayImgs.unsignedBytes( result, 2, 2, 2 );
+		Convolution< UnsignedByteType > convolver = new LineConvolution<>( new ForwardDifferenceConvolverFactory(), 2 );
+		Interval requiredSource = convolver.requiredSourceInterval( target );
+		convolver.process( source, target );
+		assertTrue( Intervals.equals( source, requiredSource ) );
+		assertArrayEquals( expected, result );
+	}
+
+	static class ForwardDifferenceConvolverFactory implements LineConvolverFactory< UnsignedByteType >
+	{
+
+		@Override public long getBorderBefore()
+		{
+			return 0;
+		}
+
+		@Override public long getBorderAfter()
+		{
+			return 1;
+		}
+
+		@Override public Runnable getConvolver( RandomAccess< ? extends UnsignedByteType > in, RandomAccess< ? extends UnsignedByteType > out, int d, long lineLength )
+		{
+			return () -> {
+				for ( int i = 0; i < lineLength; i++ )
+				{
+					int center = in.get().get();
+					in.fwd( d );
+					int front = in.get().get();
+					out.get().set( front - center );
+					out.fwd( d );
+				}
+			};
+		}
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
@@ -71,5 +71,11 @@ public class LineConvolutionTest
 				}
 			};
 		}
+
+		@Override
+		public UnsignedByteType preferredSourceType( UnsignedByteType targetType )
+		{
+			return new UnsignedByteType();
+		}
 	}
 }

--- a/src/test/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/fast_gauss/FastGaussTest.java
@@ -1,0 +1,86 @@
+package net.imglib2.algorithm.convolution.fast_gauss;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.position.FunctionRandomAccessible;
+import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class FastGaussTest
+{
+
+	public static < S extends ComplexType< S >, T extends ComplexType< T > > double psnr(
+			RandomAccessibleInterval< S > expected, RandomAccessibleInterval< T > actual )
+	{
+		double meanSquareError = meanSquareError( expected, actual );
+		if ( meanSquareError == 0.0 )
+			return Float.POSITIVE_INFINITY;
+		return ( 20 * Math.log10( max( expected ) ) - 10 * Math.log10( meanSquareError ) );
+	}
+
+	private static < S extends ComplexType< S >, T extends ComplexType< T > > double meanSquareError(
+			RandomAccessibleInterval< S > a, RandomAccessibleInterval< T > b )
+	{
+		DoubleType sum = new DoubleType( 0.0f );
+		Views.interval( Views.pair( a, b ), a ).forEach( x -> sum.set( sum.get() + sqr( x.getA().getRealDouble() - x.getB().getRealDouble() ) ) );
+		return sum.get() / Intervals.numElements( a );
+	}
+
+	private static < T extends ComplexType< T > > double max( RandomAccessibleInterval< T > a )
+	{
+		IntervalView< T > interval = Views.interval( a, a );
+		T result = interval.firstElement().createVariable();
+		interval.forEach( x -> result.setReal( Math.max( result.getRealDouble(), x.getRealDouble() ) ) );
+		return result.getRealDouble();
+	}
+
+	private static double sqr( double v )
+	{
+		return v * v;
+	}
+
+	@Test
+	public void test()
+	{
+		long[] dimensions = { 100, 100, 100 };
+		long[] peak = new long[] { 50, 50, 50 };
+		double sigma = 5.0;
+		Img< DoubleType > img = dirac( peak, dimensions );
+		FastGauss.convolve( sigma, Views.extendBorder( img ), img );
+		RandomAccessibleInterval< DoubleType > expected = gaussDistribution( sigma, peak, dimensions );
+		assertTrue( psnr( expected, img ) > 70 );
+	}
+
+	private static Img< DoubleType > dirac( long[] peak, long[] dimensions )
+	{
+		ArrayImg< DoubleType, DoubleArray > img = ArrayImgs.doubles( dimensions );
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
+		ra.setPosition( peak );
+		ra.get().setReal( 1 );
+		return img;
+	}
+
+	private static RandomAccessibleInterval< DoubleType > gaussDistribution( double sigma, long[] peak, long[] dimensions )
+	{
+		FunctionRandomAccessible< DoubleType > ra = new FunctionRandomAccessible< DoubleType >( 3, ( position, out ) -> {
+			long x = position.getIntPosition( 0 ) - peak[ 0 ];
+			long y = position.getIntPosition( 1 ) - peak[ 1 ];
+			long z = position.getIntPosition( 2 ) - peak[ 2 ];
+			out.setReal( Math.exp( -0.5 / sigma / sigma * ( x * x + y * y + z * z ) ) / Math.pow( 2 * Math.PI * sigma * sigma, 3 * 0.5 ) );
+		}, DoubleType::new );
+		return Views.interval( ra, new FinalInterval( dimensions ) );
+	}
+
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/ConvolverTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/ConvolverTest.java
@@ -1,0 +1,75 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
+
+/**
+ * @author Tobias Pietzsch
+ */
+public class ConvolverTest
+{
+	private final double[] kernel = { 1.0, 2.0, 3.0, 4.0 };
+	private final int center = 2;
+
+	private final double[] in = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 };
+
+	@Test
+	public void testConvolverNativeType()
+	{
+		final double[] out = new double[ kernel.length ];
+		final ConvolverNativeType< DoubleType > convolver = new ConvolverNativeType<>(
+				Kernel1D.asymmetric( kernel, center ),
+				ArrayImgs.doubles( in, in.length ).randomAccess(),
+				ArrayImgs.doubles( out, out.length ).randomAccess(),
+				0,
+				out.length );
+		convolver.run();
+		assertArrayEquals( kernel, out, 0 );
+	}
+
+	@Test
+	public void testConvolverNumericType()
+	{
+		final double[] out = new double[ kernel.length ];
+		final ConvolverNumericType< DoubleType > convolver = new ConvolverNumericType<>(
+				Kernel1D.asymmetric( kernel, center ),
+				ArrayImgs.doubles( in, in.length ).randomAccess(),
+				ArrayImgs.doubles( out, out.length ).randomAccess(),
+				0,
+				out.length );
+		convolver.run();
+		assertArrayEquals( kernel, out, 0 );
+	}
+
+	@Test
+	public void testDoubleConvolverRealType()
+	{
+		final double[] out = new double[ kernel.length ];
+		final DoubleConvolverRealType convolver = new DoubleConvolverRealType(
+				Kernel1D.asymmetric( kernel, center ),
+				ArrayImgs.doubles( in, in.length ).randomAccess(),
+				ArrayImgs.doubles( out, out.length ).randomAccess(),
+				0,
+				out.length );
+		convolver.run();
+		assertArrayEquals( kernel, out, 0 );
+	}
+
+	@Test
+	public void testFloatConvolverRealType()
+	{
+		final double[] out = new double[ kernel.length ];
+		final FloatConvolverRealType convolver = new FloatConvolverRealType(
+				Kernel1D.asymmetric( kernel, center ),
+				ArrayImgs.doubles( in, in.length ).randomAccess(),
+				ArrayImgs.doubles( out, out.length ).randomAccess(),
+				0,
+				out.length );
+		convolver.run();
+		assertArrayEquals( kernel, out, 0 );
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/ConvolverTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/ConvolverTest.java
@@ -2,54 +2,51 @@ package net.imglib2.algorithm.convolution.kernel;
 
 import static org.junit.Assert.assertArrayEquals;
 
+import net.imglib2.RandomAccess;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.Test;
 
 /**
+ * Tests {@link ConvolverNativeType}, {@link ConvolverNumericType},
+ * {@link DoubleConvolverRealType} and {@link FloatConvolverRealType}.
+ *
  * @author Tobias Pietzsch
  */
 public class ConvolverTest
 {
-	private final double[] kernel = { 1.0, 2.0, 3.0, 4.0 };
-	private final int center = 2;
-
-	private final double[] in = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 };
-
 	@Test
 	public void testConvolverNativeType()
 	{
-		final double[] out = new double[ kernel.length ];
-		final ConvolverNativeType< DoubleType > convolver = new ConvolverNativeType<>(
-				Kernel1D.asymmetric( kernel, center ),
-				ArrayImgs.doubles( in, in.length ).randomAccess(),
-				ArrayImgs.doubles( out, out.length ).randomAccess(),
-				0,
-				out.length );
-		convolver.run();
-		assertArrayEquals( kernel, out, 0 );
+		testConvolver( ConvolverNativeType::new );
 	}
 
 	@Test
 	public void testConvolverNumericType()
 	{
-		final double[] out = new double[ kernel.length ];
-		final ConvolverNumericType< DoubleType > convolver = new ConvolverNumericType<>(
-				Kernel1D.asymmetric( kernel, center ),
-				ArrayImgs.doubles( in, in.length ).randomAccess(),
-				ArrayImgs.doubles( out, out.length ).randomAccess(),
-				0,
-				out.length );
-		convolver.run();
-		assertArrayEquals( kernel, out, 0 );
+		testConvolver( ConvolverNumericType::new );
 	}
 
 	@Test
 	public void testDoubleConvolverRealType()
 	{
+		testConvolver( DoubleConvolverRealType::new );
+	}
+
+	@Test
+	public void testFloatConvolverRealType()
+	{
+		testConvolver( FloatConvolverRealType::new );
+	}
+
+	private void testConvolver( ConvolverConstructor< DoubleType > constructor )
+	{
+		final double[] kernel = { 1.0, 2.0, 3.0, 4.0 };
+		final int center = 2;
+		final double[] in = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 };
 		final double[] out = new double[ kernel.length ];
-		final DoubleConvolverRealType convolver = new DoubleConvolverRealType(
+		final Runnable convolver = constructor.create(
 				Kernel1D.asymmetric( kernel, center ),
 				ArrayImgs.doubles( in, in.length ).randomAccess(),
 				ArrayImgs.doubles( out, out.length ).randomAccess(),
@@ -59,17 +56,8 @@ public class ConvolverTest
 		assertArrayEquals( kernel, out, 0 );
 	}
 
-	@Test
-	public void testFloatConvolverRealType()
+	private interface ConvolverConstructor< T >
 	{
-		final double[] out = new double[ kernel.length ];
-		final FloatConvolverRealType convolver = new FloatConvolverRealType(
-				Kernel1D.asymmetric( kernel, center ),
-				ArrayImgs.doubles( in, in.length ).randomAccess(),
-				ArrayImgs.doubles( out, out.length ).randomAccess(),
-				0,
-				out.length );
-		convolver.run();
-		assertArrayEquals( kernel, out, 0 );
+		Runnable create( final Kernel1D kernel, final RandomAccess< ? extends T > in, final RandomAccess< ? extends T > out, final int d, final long lineLength );
 	}
 }

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/Kernel1DTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/Kernel1DTest.java
@@ -1,0 +1,37 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class Kernel1DTest
+{
+
+	@Test
+	public void testSymmetric()
+	{
+		Kernel1D kernel = Kernel1D.symmetric( 2, 1 );
+		assertEquals( -1, kernel.min() );
+		assertEquals( 1, kernel.max() );
+		assertArrayEquals( new double[] { 1, 2, 1 }, kernel.fullKernel(), 0.0 );
+	}
+
+	@Test
+	public void testAsymmetric()
+	{
+		Kernel1D kernel = Kernel1D.asymmetric( new double[] { 1, 2, 0, 3 }, 1 );
+		assertEquals( -1, kernel.min() );
+		assertEquals( 2, kernel.max() );
+		assertArrayEquals( new double[] { 1, 2, 0, 3 }, kernel.fullKernel(), 0.0 );
+	}
+
+	@Test
+	public void testCentralAsymmetric()
+	{
+		Kernel1D kernel = Kernel1D.centralAsymmetric( -1, 0, 1 );
+		assertEquals( -1, kernel.min() );
+		assertEquals( 1, kernel.max() );
+		assertArrayEquals( new double[] { -1, 0, 1 }, kernel.fullKernel(), 0.0 );
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactoryTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactoryTest.java
@@ -23,65 +23,12 @@ public class KernelConvolverFactoryTest
 {
 
 	@Test
-	public void testDoubleConvolver()
-	{
-		testConvolver( DoubleConvolverRealType.class );
-	}
-
-	@Test
-	public void testFloatConvolver()
-	{
-		testConvolver( FloatConvolverRealType.class );
-	}
-
-	@Test
-	public void testNativeConvolver()
-	{
-		testConvolver( ConvolverNativeType.class );
-	}
-
-	@Test
-	public void testNumericConvolver()
-	{
-		testConvolver( ConvolverNumericType.class );
-	}
-
-	public void testConvolver( Class< ? extends Runnable > expectedConvolverClass )
-	{
-		try
-		{
-			double[] halfKernel = { 3, 2, 1 };
-			double[] in = { 5, 0, 1, 0, 0, 0, 0, 0, 0, 0 };
-			double[] expected = { 8, 2, 1, 0, 0, 0 };
-			int lineLength = in.length - 2 * ( halfKernel.length - 1 );
-			double[] actual = new double[ lineLength ];
-
-			Img< DoubleType > inImg = ArrayImgs.doubles( in, in.length );
-			Img< DoubleType > outImg = ArrayImgs.doubles( actual, actual.length );
-			Runnable convolver = expectedConvolverClass
-					.getConstructor( Kernel1D.class, RandomAccess.class, RandomAccess.class, int.class, long.class )
-					.newInstance( Kernel1D.symmetric( halfKernel ), inImg.randomAccess(), outImg.randomAccess(), 0, lineLength );
-			convolver.run();
-			assertArrayEquals( expected, actual, 0.0001 );
-		}
-		catch ( NoSuchMethodException e )
-		{
-			fail( "The class " + expectedConvolverClass.getSimpleName() + " misses the constructor needed for KernelConvolverFactory." );
-		}
-		catch ( IllegalAccessException | InstantiationException | InvocationTargetException e )
-		{
-			fail( "The constructor of class " + expectedConvolverClass.getSimpleName() + " must be public for class copying." );
-		}
-	}
-
-	@Test
 	public void test()
 	{
 		testFactoryTypeMatching( DoubleConvolverRealType.class, ArrayImgs.doubles( 1 ) );
 		testFactoryTypeMatching( FloatConvolverRealType.class, ArrayImgs.bytes( 1 ) );
 		testFactoryTypeMatching( ConvolverNativeType.class, ArrayImgs.argbs( 1 ) );
-		ListImg< ? extends NumericType< ? > > image = createImageOfNumericType();
-		testFactoryTypeMatching( ConvolverNumericType.class, image );
+		testFactoryTypeMatching( ConvolverNumericType.class, createImageOfNumericType() );
 	}
 
 	private ListImg< ? extends NumericType< ? > > createImageOfNumericType()

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactoryTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/KernelConvolverFactoryTest.java
@@ -1,0 +1,101 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.composite.RealComposite;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Matthias Arzt
+ */
+public class KernelConvolverFactoryTest
+{
+
+	@Test
+	public void testDoubleConvolver()
+	{
+		testConvolver( DoubleConvolverRealType.class );
+	}
+
+	@Test
+	public void testFloatConvolver()
+	{
+		testConvolver( FloatConvolverRealType.class );
+	}
+
+	@Test
+	public void testNativeConvolver()
+	{
+		testConvolver( ConvolverNativeType.class );
+	}
+
+	@Test
+	public void testNumericConvolver()
+	{
+		testConvolver( ConvolverNumericType.class );
+	}
+
+	public void testConvolver( Class< ? extends Runnable > expectedConvolverClass )
+	{
+		try
+		{
+			double[] halfKernel = { 3, 2, 1 };
+			double[] in = { 5, 0, 1, 0, 0, 0, 0, 0, 0, 0 };
+			double[] expected = { 8, 2, 1, 0, 0, 0 };
+			int lineLength = in.length - 2 * ( halfKernel.length - 1 );
+			double[] actual = new double[ lineLength ];
+
+			Img< DoubleType > inImg = ArrayImgs.doubles( in, in.length );
+			Img< DoubleType > outImg = ArrayImgs.doubles( actual, actual.length );
+			Runnable convolver = expectedConvolverClass
+					.getConstructor( Kernel1D.class, RandomAccess.class, RandomAccess.class, int.class, long.class )
+					.newInstance( Kernel1D.symmetric( halfKernel ), inImg.randomAccess(), outImg.randomAccess(), 0, lineLength );
+			convolver.run();
+			assertArrayEquals( expected, actual, 0.0001 );
+		}
+		catch ( NoSuchMethodException e )
+		{
+			fail( "The class " + expectedConvolverClass.getSimpleName() + " misses the constructor needed for KernelConvolverFactory." );
+		}
+		catch ( IllegalAccessException | InstantiationException | InvocationTargetException e )
+		{
+			fail( "The constructor of class " + expectedConvolverClass.getSimpleName() + " must be public for class copying." );
+		}
+	}
+
+	@Test
+	public void test()
+	{
+		testFactoryTypeMatching( DoubleConvolverRealType.class, ArrayImgs.doubles( 1 ) );
+		testFactoryTypeMatching( FloatConvolverRealType.class, ArrayImgs.bytes( 1 ) );
+		testFactoryTypeMatching( ConvolverNativeType.class, ArrayImgs.argbs( 1 ) );
+		ListImg< ? extends NumericType< ? > > image = createImageOfNumericType();
+		testFactoryTypeMatching( ConvolverNumericType.class, image );
+	}
+
+	private ListImg< ? extends NumericType< ? > > createImageOfNumericType()
+	{
+		// NB: The returned pixel type is not even NativeType.
+		NumericType< ? > type = new RealComposite<>( ArrayImgs.bytes( 1 ).randomAccess(), 1 );
+		return new ListImg<>( Collections.singleton( type ), 1 );
+	}
+
+	private void testFactoryTypeMatching( Class< ? > expectedConvolver, Img< ? extends NumericType< ? > > image )
+	{
+		KernelConvolverFactory factory = new KernelConvolverFactory( Kernel1D.symmetric( new double[] { 1 } ) );
+		Runnable convolver = factory.getConvolver( image.randomAccess(), image.randomAccess(), 0, image.dimension( 0 ) );
+		// NB: The classes are different because ClassCopyProvider is used, but the names are still equal.
+		assertEquals( expectedConvolver.getName(), convolver.getClass().getName() );
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolutionTest.java
@@ -1,0 +1,125 @@
+package net.imglib2.algorithm.convolution.kernel;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Matthias Arzt
+ */
+public class SeparableKernelConvolutionTest
+{
+
+	private final ExecutorService executorService = Executors.newFixedThreadPool( 1 );
+
+	@Test
+	public void testCalculateConvolutionSourceInterval()
+	{
+		Kernel1D kernel = Kernel1D.asymmetric( new double[ 4 ], 1 );
+		Interval result = SeparableKernelConvolution.convolution1d( kernel, 1 )
+				.requiredSourceInterval( Intervals.createMinMax( 1, 0, 5, 7, 10, 5 ) );
+		Interval expected = Intervals.createMinMax( 1, -2, 5, 7, 11, 5 );
+		assertTrue( Intervals.equals( expected, result ) );
+	}
+
+	@Test
+	public void test1DConvolution()
+	{
+		double[][] kernels = { { 1.0, 2.0, 3.0, 4.0 } };
+		int[] centers = { 2 };
+		testSeparableConvolution( Kernel1D.asymmetric( kernels, centers ) );
+
+	}
+
+	@Test
+	public void test2DConvolution()
+	{
+		double[][] kernels = { { 1.0, 0.0, -1.0 }, { 1.0, 2.0, 1.0 } };
+		testSeparableConvolution( Kernel1D.centralAsymmetric( kernels ) );
+
+	}
+
+	@Test
+	public void test3DConvolution()
+	{
+		double[][] kernels = { { 1, 6, 8, 6 }, { 2, 7, -5 }, { 1, 2 } };
+		int[] centers = { 0, 3, 4 };
+		testSeparableConvolution( Kernel1D.asymmetric( kernels, centers ) );
+
+	}
+
+	private void testSeparableConvolution( Kernel1D[] kernels1d )
+	{
+		// NB: The result of a convolution between a dirac signal and a kernel is again the kernel.
+		RandomAccessible< DoubleType > dirac = getDirac( kernels1d.length );
+		RandomAccessibleInterval< DoubleType > expected = getKernel( kernels1d );
+		RandomAccessibleInterval< DoubleType > result = createImg( expected );
+		SeparableKernelConvolution.convolve( kernels1d, dirac, result );
+		assertImagesEqual( expected, result, 0.0 );
+	}
+
+	private RandomAccessible< DoubleType > getDirac( int n )
+	{
+		long[] dimensions = IntStream.range( 0, n ).mapToLong( k -> 1 ).toArray();
+		RandomAccessibleInterval< DoubleType > one = ArrayImgs.doubles( new double[] { 1 }, dimensions );
+		return Views.extendZero( one );
+	}
+
+	private RandomAccessibleInterval< DoubleType > getKernel( Kernel1D[] kernels )
+	{
+		long[] kernelSizes = Stream.of( kernels ).mapToLong( kernel -> kernel.size() ).toArray();
+		double[][] fullKernels = Stream.of( kernels ).map( kernel -> kernel.fullKernel() ).toArray( double[][]::new );
+		Img< DoubleType > result = ArrayImgs.doubles( kernelSizes );
+		Cursor< DoubleType > cursor = result.cursor();
+		while ( cursor.hasNext() )
+		{
+			cursor.next().setReal(
+					IntStream.range( 0, kernels.length )
+							.mapToDouble( d -> fullKernels[ d ][ cursor.getIntPosition( d ) ] )
+							.reduce( 1, ( a, b ) -> a * b )
+			);
+		}
+		long[] minusCenters = Stream.of( kernels ).mapToLong( kernel -> kernel.min() ).toArray();
+		return Views.translate( result, minusCenters );
+	}
+
+	@Test( expected = IllegalArgumentException.class )
+	public void testTypeMisMatch()
+	{
+		Img< FloatType > source = ArrayImgs.floats( 1 );
+		Img< ARGBType > target = ArrayImgs.argbs( 1 );
+		SeparableKernelConvolution.convolution1d( Kernel1D.symmetric( 1 ), 0 )
+				.process( Views.extendBorder( source ), target );
+	}
+
+	private static RandomAccessibleInterval< DoubleType > createImg( Interval interval )
+	{
+		Img< DoubleType > image = ArrayImgs.doubles( Intervals.dimensionsAsLongArray( interval ) );
+		return Views.translate( image, Intervals.minAsLongArray( interval ) );
+	}
+
+	private static void assertImagesEqual( RandomAccessibleInterval< DoubleType > expected, RandomAccessibleInterval< DoubleType > actual, double delta )
+	{
+		assertTrue( Intervals.equals( expected, actual ) );
+		Views.interval( Views.pair( expected, actual ), expected ).forEach( p -> assertEquals( p.getA().getRealDouble(), p.getB().getRealDouble(), delta ) );
+	}
+
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolutionTest.java
@@ -7,6 +7,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.convolution.Convolution;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.test.ImgLib2Assert;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -21,8 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -76,7 +75,7 @@ public class SeparableKernelConvolutionTest
 		RandomAccessibleInterval< DoubleType > expected = getKernel( kernels1d );
 		RandomAccessibleInterval< DoubleType > result = createImg( expected );
 		SeparableKernelConvolution.convolve( kernels1d, dirac, result );
-		assertImagesEqual( expected, result, 0.0 );
+		ImgLib2Assert.assertImageEquals( expected, result );
 	}
 
 	private RandomAccessible< DoubleType > getDirac( int n )
@@ -119,24 +118,16 @@ public class SeparableKernelConvolutionTest
 		return Views.translate( image, Intervals.minAsLongArray( interval ) );
 	}
 
-	private static void assertImagesEqual( RandomAccessibleInterval< DoubleType > expected, RandomAccessibleInterval< DoubleType > actual, double delta )
-	{
-		assertTrue( Intervals.equals( expected, actual ) );
-		Views.interval( Views.pair( expected, actual ), expected ).forEach( p -> assertEquals( p.getA().getRealDouble(), p.getB().getRealDouble(), delta ) );
-	}
-
 	@Test
 	public void testPrecisionOfTemporaryImages() {
 		// NB: This test assures that for convolution on UnsignedByteType,
 		// the pixel type to store intermediate results can store 0.1, hence
 		// is FloatType or DoubleType.
-		final byte[] inputPixels = { 1 };
-		final byte[] outputPixels = new byte[ 1 ];
 		final Kernel1D[] kernels = { Kernel1D.symmetric( 0.1 ), Kernel1D.symmetric( 10 ) };
-		Img< UnsignedByteType > input = ArrayImgs.unsignedBytes( inputPixels, 1, 1 );
-		Img< UnsignedByteType > output = ArrayImgs.unsignedBytes( outputPixels, 1, 1 );
+		Img< UnsignedByteType > input = ArrayImgs.unsignedBytes( new byte[] { 1 }, 1, 1 );
+		Img< UnsignedByteType > output = ArrayImgs.unsignedBytes( new byte[] { 0 }, 1, 1 );
 		SeparableKernelConvolution.convolution( kernels ).process( input, output );
-		assertArrayEquals( inputPixels, outputPixels );
+		ImgLib2Assert.assertImageEquals( input, output );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolutionTest.java
@@ -7,6 +7,7 @@ import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.test.ImgLib2Assert;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
@@ -15,9 +16,6 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Matthias Arzt
@@ -40,7 +38,7 @@ public class SeparableSymmetricConvolutionTest
 	{
 		RandomAccessibleInterval< DoubleType > target = createImg( expected );
 		SeparableSymmetricConvolution.convolve( halfKernels, getDirac( halfKernels.length ), target, service );
-		assertImagesEqual( expected, target, 0.0 );
+		ImgLib2Assert.assertImageEquals( expected, target );
 	}
 
 	@Test
@@ -50,7 +48,7 @@ public class SeparableSymmetricConvolutionTest
 		ConvolverFactory< DoubleType, DoubleType > factory = FloatConvolverRealType.factory();
 		SeparableSymmetricConvolution.convolve( halfKernels, getDirac( halfKernels.length ), target,
 				factory, factory, factory, factory, new ArrayImgFactory<>(), new DoubleType(), service );
-		assertImagesEqual( expected, target, 0.0 );
+		ImgLib2Assert.assertImageEquals( expected, target );
 	}
 
 	@Test
@@ -75,11 +73,5 @@ public class SeparableSymmetricConvolutionTest
 		// TODO: better name, move to ArrayImgs class
 		Img< DoubleType > image = ArrayImgs.doubles( Intervals.dimensionsAsLongArray( interval ) );
 		return Views.translate( image, Intervals.minAsLongArray( interval ) );
-	}
-
-	public static void assertImagesEqual( RandomAccessibleInterval< DoubleType > expected, RandomAccessibleInterval< DoubleType > actual, double delta )
-	{
-		assertTrue( Intervals.equals( expected, actual ) );
-		Views.interval( Views.pair( expected, actual ), expected ).forEach( p -> assertEquals( p.getA().getRealDouble(), p.getB().getRealDouble(), delta ) );
 	}
 }

--- a/src/test/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/gauss3/SeparableSymmetricConvolutionTest.java
@@ -1,0 +1,85 @@
+package net.imglib2.algorithm.gauss3;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Matthias Arzt
+ */
+public class SeparableSymmetricConvolutionTest
+{
+
+	private ExecutorService service = Executors.newFixedThreadPool( 1 );
+
+	private final double[][] halfKernels = new double[][] { { 8, 3, 1 }, { 2, 1 } };
+
+	private final RandomAccessibleInterval< DoubleType > expected = Views.translate( ArrayImgs.doubles( new double[] {
+			1, 3, 8, 3, 1,
+			2, 6, 16, 6, 2,
+			1, 3, 8, 3, 1
+	}, 5, 3 ), -2, -1 );
+
+	@Test
+	public void testConvolve() throws IncompatibleTypeException
+	{
+		RandomAccessibleInterval< DoubleType > target = createImg( expected );
+		SeparableSymmetricConvolution.convolve( halfKernels, getDirac( halfKernels.length ), target, service );
+		assertImagesEqual( expected, target, 0.0 );
+	}
+
+	@Test
+	public void testConvolve2()
+	{
+		RandomAccessibleInterval< DoubleType > target = createImg( expected );
+		ConvolverFactory< DoubleType, DoubleType > factory = FloatConvolverRealType.factory();
+		SeparableSymmetricConvolution.convolve( halfKernels, getDirac( halfKernels.length ), target,
+				factory, factory, factory, factory, new ArrayImgFactory<>(), new DoubleType(), service );
+		assertImagesEqual( expected, target, 0.0 );
+	}
+
+	@Test
+	public void testConcolve1d()
+	{
+		double[] kernel = { 2, 1 };
+		RandomAccessible< DoubleType > source = Views.extendBorder( ArrayImgs.doubles( new double[] { 1, 2, 0, 1, 3 }, 5 ) );
+		RandomAccessibleInterval< DoubleType > target = ArrayImgs.doubles( new double[] { 5, 5, 3, 5 }, 4 );
+		ConvolverFactory< DoubleType, DoubleType > factory = FloatConvolverRealType.factory();
+		SeparableSymmetricConvolution.convolve1d( kernel, source, target, factory, service );
+	}
+
+	private RandomAccessible< DoubleType > getDirac( int n )
+	{
+		long[] dimensions = IntStream.range( 0, n ).mapToLong( k -> 1 ).toArray();
+		RandomAccessibleInterval< DoubleType > one = ArrayImgs.doubles( new double[] { 1 }, dimensions );
+		return Views.extendZero( one );
+	}
+
+	public static RandomAccessibleInterval< DoubleType > createImg( Interval interval )
+	{
+		// TODO: better name, move to ArrayImgs class
+		Img< DoubleType > image = ArrayImgs.doubles( Intervals.dimensionsAsLongArray( interval ) );
+		return Views.translate( image, Intervals.minAsLongArray( interval ) );
+	}
+
+	public static void assertImagesEqual( RandomAccessibleInterval< DoubleType > expected, RandomAccessibleInterval< DoubleType > actual, double delta )
+	{
+		assertTrue( Intervals.equals( expected, actual ) );
+		Views.interval( Views.pair( expected, actual ), expected ).forEach( p -> assertEquals( p.getA().getRealDouble(), p.getB().getRealDouble(), delta ) );
+	}
+}


### PR DESCRIPTION
Separable asymmetric kernels are used in image processing.
One example: The derivative of a gauss kernel is a separable, asymmetric kernel, and is used to calculate exact derivatives of an gaussian blurred image.

This PR deprecates the current separable symmetric convolution algorithm. And adds generalized algorithm for separable convolution. The new algorithm has been benchmarked against the current implementation an proved to be just as fast.

Gauss3 is changed to use the new implementation.