### PR TITLE
use the current version of pom-imglib2 as parent. Currently, it was b…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>9.0.0</version>
+		<version>10.0.1</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
…uilt against imglib2-3.3.0, which failed when any algorithm instantiates a CellImg itself due to a change in the constructor methods.

This is critical!