### PR TITLE
Remove trove version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>
 			<artifactId>trove4j</artifactId>
-			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ojalgo</groupId>


### PR DESCRIPTION
trove is managed now (at the same version 3.0.3 as specified in pom.xml) and eclipse shows this warning:
> Duplicating managed version 3.0.3 for trove4j