### PR TITLE
Bump imglib2 dependency to 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
+			<version>5.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/src/test/java/tests/labeling/WatershedTest.java
+++ b/src/test/java/tests/labeling/WatershedTest.java
@@ -39,22 +39,22 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.junit.Test;
+
 import net.imglib2.Cursor;
 import net.imglib2.algorithm.labeling.AllConnectedComponents;
 import net.imglib2.algorithm.labeling.Watershed;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.labeling.LabelingType;
 import net.imglib2.labeling.NativeImgLabeling;
 import net.imglib2.type.numeric.integer.IntType;
-import net.imglib2.util.Fraction;
-
-import org.junit.Test;
 
 /**
  * TODO
- * 
+ *
  * @author Lee Kamentsky
  */
 public class WatershedTest
@@ -64,9 +64,9 @@ public class WatershedTest
 		final long[] imageDimensions = new long[] { image.length, image[ 0 ].length };
 		final long[] seedDimensions = new long[] { seeds.length, seeds[ 0 ].length };
 		final long[] outputDimensions = new long[] { expected.length, expected[ 0 ].length };
-		final NativeImgLabeling< Integer, IntType > seedLabeling = new NativeImgLabeling< Integer, IntType >( new ArrayImgFactory< IntType >().create( seedDimensions, new IntType() ) );
-		final NativeImgLabeling< Integer, IntType > outputLabeling = new NativeImgLabeling< Integer, IntType >( new ArrayImgFactory< IntType >().create( outputDimensions, new IntType() ) );
-		final NativeImg< IntType, ? extends IntAccess > imageImage = new ArrayImgFactory< IntType >().createIntInstance( imageDimensions, new Fraction() );
+		final NativeImgLabeling< Integer, IntType > seedLabeling = new NativeImgLabeling< >( new ArrayImgFactory< IntType >().create( seedDimensions, new IntType() ) );
+		final NativeImgLabeling< Integer, IntType > outputLabeling = new NativeImgLabeling< >( new ArrayImgFactory< IntType >().create( outputDimensions, new IntType() ) );
+		final NativeImg< IntType, ? extends IntAccess > imageImage = ArrayImgs.ints( imageDimensions );
 		imageImage.setLinkedType( new IntType( imageImage ) );
 		/*
 		 * Fill the image.


### PR DESCRIPTION
This bumps the imglib2 dependency to new major version 5. Only one test case needed adaption and all the tests succeed.