### PR TITLE
ImgMath fixes

### DIFF
--- a/src/main/java/net/imglib2/algorithm/math/Add.java
+++ b/src/main/java/net/imglib2/algorithm/math/Add.java
@@ -26,8 +26,10 @@ public final class Add extends ABinaryFunction
 			final O tmp,
 			final Map< String, O > bindings,
 			final Converter< RealType< ? >, O > converter,
-			Map< Variable< O >, OFunction< O > > imgSources )
+			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Addition< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Addition< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -79,7 +79,7 @@ public class Compute
 					output.setReal( input.getRealDouble() );
 				}
 			};
-		
+			
 		// Recursive copy: initializes interval iterators and sets temporary computation holder
 		final OFunction< O > f = this.operation.reInit(
 				target.randomAccess().get().createVariable(),
@@ -87,7 +87,7 @@ public class Compute
 				converter, null );
 		
 		// Check compatible iteration order and dimensions
-		if ( compatible_iteration_order )
+		if ( this.compatible_iteration_order )
 		{
 			// Evaluate function for every pixel
 			for ( final O output : Views.iterable( target ) )

--- a/src/main/java/net/imglib2/algorithm/math/Div.java
+++ b/src/main/java/net/imglib2/algorithm/math/Div.java
@@ -27,8 +27,10 @@ public final class Div extends ABinaryFunction
 			final O tmp,
 			final Map< String, O > bindings,
 			final Converter< RealType< ? >, O > converter,
-			Map< Variable< O >, OFunction< O > > imgSources )
+			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Division< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Division< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Equal.java
+++ b/src/main/java/net/imglib2/algorithm/math/Equal.java
@@ -23,6 +23,8 @@ public final class Equal extends Compare
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Equality< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Equality< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/GreaterThan.java
+++ b/src/main/java/net/imglib2/algorithm/math/GreaterThan.java
@@ -21,8 +21,10 @@ public final class GreaterThan extends Compare
 			final O tmp,
 			final Map< String, O > bindings,
 			final Converter< RealType< ? >, O > converter,
-			Map< Variable< O >, OFunction< O > > imgSources )
+			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new IsGreaterThan< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new IsGreaterThan< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -232,4 +232,14 @@ public class ImgMath
 	{
 		return new Else( o );
 	}
+	
+	static public final < T extends RealType< T > > ImgSource< T > img( final RandomAccessibleInterval< T > rai )
+	{
+		return new ImgSource< T >( rai );
+	}
+	
+	static public final NumberSource number( final Number number )
+	{
+		return new NumberSource( number );
+	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/ImgSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgSource.java
@@ -29,7 +29,9 @@ public class ImgSource< I extends RealType< I > > implements IFunction
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
 		// Optimization: if input image type is the same or a subclass of
-		// the output image type (represented here by tmp), then avoid the converter.
+		// the output image type (represented here by tmp), then avoid the converter
+		// but only if the targetImg is different than this.rai: otherwise, an intermediate
+		// computation result holder must be used (the scrap).
 		final OFunction< O > s;
 		if ( tmp.getClass().isAssignableFrom( this.rai.randomAccess().get().getClass() ) )
 			s = new ImgSourceIterableDirect< O >( ( RandomAccessibleInterval< O > )this.rai );

--- a/src/main/java/net/imglib2/algorithm/math/LessThan.java
+++ b/src/main/java/net/imglib2/algorithm/math/LessThan.java
@@ -23,6 +23,8 @@ public final class LessThan extends Compare
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new IsLessThan< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new IsLessThan< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Let.java
+++ b/src/main/java/net/imglib2/algorithm/math/Let.java
@@ -68,7 +68,9 @@ public final class Let implements IFunction, IBinaryFunction
 		final O scrap = tmp.copy();
 		final Map< String, O > rebind = new HashMap<>( bindings );
 		rebind.put( this.varName, scrap );
-		return new LetBinding< O >( scrap, this.varName, this.varValue.reInit( tmp, rebind, converter, imgSources ), this.body.reInit( tmp, rebind, converter, imgSources ) );
+		return new LetBinding< O >( scrap, this.varName,
+				this.varValue.reInit( tmp, rebind, converter, imgSources ),
+				this.body.reInit( tmp, rebind, converter, imgSources ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/Max.java
+++ b/src/main/java/net/imglib2/algorithm/math/Max.java
@@ -28,6 +28,8 @@ public final class Max extends ABinaryFunction
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Maximum< O >( this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Maximum< O >(
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Min.java
+++ b/src/main/java/net/imglib2/algorithm/math/Min.java
@@ -28,6 +28,8 @@ public final class Min extends ABinaryFunction
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Minimum< O >( this.a.reInit(tmp, bindings, converter, imgSources), this.b.reInit(tmp, bindings, converter, imgSources) );
+		return new Minimum< O >(
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Mul.java
+++ b/src/main/java/net/imglib2/algorithm/math/Mul.java
@@ -28,6 +28,8 @@ public final class Mul extends ABinaryFunction
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Multiplication< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Multiplication< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/NotEqual.java
+++ b/src/main/java/net/imglib2/algorithm/math/NotEqual.java
@@ -22,6 +22,8 @@ public final class NotEqual extends Compare
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new NotEquality< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new NotEquality< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Sub.java
+++ b/src/main/java/net/imglib2/algorithm/math/Sub.java
@@ -28,6 +28,8 @@ public final class Sub extends ABinaryFunction
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Subtraction< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ), this.b.reInit( tmp, bindings, converter, imgSources ) );
+		return new Subtraction< O >( tmp.copy(),
+				this.a.reInit( tmp, bindings, converter, imgSources ),
+				this.b.reInit( tmp, bindings, converter, imgSources ) );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/AUnaryFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/AUnaryFunction.java
@@ -2,7 +2,7 @@ package net.imglib2.algorithm.math.abstractions;
 
 import net.imglib2.type.numeric.RealType;
 
-abstract public class AUnaryFunction extends VarargsFunction implements IUnaryFunction
+abstract public class AUnaryFunction implements IUnaryFunction
 {
 	protected final IFunction a;
 

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/VarargsFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/VarargsFunction.java
@@ -5,8 +5,11 @@ import java.lang.reflect.Constructor;
 abstract public class VarargsFunction
 {
 	final public IFunction[] wrapMap( final Object[] obs )
-	{	
+	{
 		try {
+			if ( 2 == obs.length )
+				return new IFunction[]{ Util.wrap( obs[ 0 ] ), Util.wrap( obs[ 1 ]) };
+			
 			final Constructor< ? > constructor = this.getClass().getConstructor( new Class[]{ Object.class, Object.class } );
 			ABinaryFunction a = ( ABinaryFunction )constructor.newInstance( obs[0], obs[1] );
 			ABinaryFunction b;


### PR DESCRIPTION
Two fixes for ImgMath:
 1. A critical issue, that appears only in scripting languages that fail to find the 2-argument constructor of many functions, and instead use the varargs argument with 2 arguments. The Util.wrapMap was not ready to work with less than 3 arguments.
2. A minor issue: lack of two static functions in ImgMath: img (to wrap a RandomAccessibleInterval) and number (to wrap a number). These two enable convenient operations like e.g. copying and image into another, and filling an image with a number.