### PR TITLE
Fix issue 77

### DIFF
--- a/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolution.java
@@ -39,7 +39,7 @@ public abstract class AbstractMultiThreadedConvolution< T > implements Convoluti
 	{
 		if ( executor == null )
 		{
-			final int numThreads = suggestNumThreads();
+			final int numThreads = Runtime.getRuntime().availableProcessors();
 			final ExecutorService executor = Executors.newFixedThreadPool( numThreads );
 			try
 			{
@@ -56,15 +56,13 @@ public abstract class AbstractMultiThreadedConvolution< T > implements Convoluti
 		}
 	}
 
-	private int getNumThreads( final ExecutorService executor )
+	static int getNumThreads( final ExecutorService executor )
 	{
-		if ( executor instanceof ThreadPoolExecutor )
-			return ( ( ThreadPoolExecutor ) executor ).getMaximumPoolSize();
-		return suggestNumThreads();
+		int maxPoolSize = ( executor instanceof ThreadPoolExecutor ) ?
+				( ( ThreadPoolExecutor ) executor ).getMaximumPoolSize() :
+				Integer.MAX_VALUE;
+		int availableProcessors = Runtime.getRuntime().availableProcessors();
+		return Math.max(1, Math.min(availableProcessors, maxPoolSize));
 	}
 
-	private int suggestNumThreads()
-	{
-		return Runtime.getRuntime().availableProcessors();
-	}
 }

--- a/src/test/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/AbstractMultiThreadedConvolutionTest.java
@@ -1,0 +1,35 @@
+package net.imglib2.algorithm.convolution;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests {@link AbstractMultiThreadedConvolution}
+ *
+ * @author Matthias Arzt
+ */
+public class AbstractMultiThreadedConvolutionTest
+{
+	@Test
+	public void testSuggestNumTasksFixedThreadPool() {
+		if ( Runtime.getRuntime().availableProcessors() < 3 )
+			return;
+		final ExecutorService executor = Executors.newFixedThreadPool( 3 );
+		int result = AbstractMultiThreadedConvolution.getNumThreads( executor );
+		assertEquals( 3, result );
+	}
+
+	@Test
+	public void testSuggestNumTasksCachedThreadPool() {
+		final ExecutorService executor = Executors.newCachedThreadPool();
+		int result = AbstractMultiThreadedConvolution.getNumThreads( executor );
+		assertTrue( Runtime.getRuntime().availableProcessors() >= result );
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/convolution/LineConvolutionTest.java
@@ -8,6 +8,8 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.util.Intervals;
 import org.junit.Test;
 
+import java.util.concurrent.Executors;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -43,6 +45,16 @@ public class LineConvolutionTest
 		convolver.process( source, target );
 		assertTrue( Intervals.equals( source, requiredSource ) );
 		assertArrayEquals( expected, result );
+	}
+
+	@Test
+	public void testNumTasksEqualsIntegerMaxValue() {
+		byte[] result = new byte[ 1 ];
+		Img< UnsignedByteType > out = ArrayImgs.unsignedBytes( result, result.length );
+		Img< UnsignedByteType > in = ArrayImgs.unsignedBytes( new byte[] { 1, 2 }, 2 );
+		final LineConvolution< UnsignedByteType > convolution = new LineConvolution<>( new ForwardDifferenceConvolverFactory(), 0 );
+		convolution.process( in, out, Executors.newSingleThreadExecutor(), Integer.MAX_VALUE );
+		assertArrayEquals( new byte[] { 1 }, result );
 	}
 
 	static class ForwardDifferenceConvolverFactory implements LineConvolverFactory< UnsignedByteType >


### PR DESCRIPTION
Fix https://github.com/imglib/imglib2-algorithm/issues/77

Executors.newCachedThreadPool().getMaximumPoolSize() return Integer.MAX_VALUE.
This caused some problems (number overflow) trying to parallelize Gauss convolution.
This PR makes some changes that improve the code for parallelization when the number
of threads is very high.
