### PR TITLE
Allow wider Shape generics in lists in morphology ops

### DIFF
--- a/src/main/java/net/imglib2/algorithm/morphology/BlackTopHat.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/BlackTopHat.java
@@ -89,7 +89,7 @@ public class BlackTopHat
 	 *            sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends RealType< T >> Img< T > blackTopHat( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> Img< T > blackTopHat( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final Img< T > closed = Closing.close( source, strels, numThreads );
 		MorphologyUtils.subAAB( closed, source, numThreads );
@@ -140,7 +140,7 @@ public class BlackTopHat
 	 *            subtract them.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T > > Img< T > blackTopHat( final Img< T > source, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T > > Img< T > blackTopHat( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		final Img< T > closed = Closing.close( source, strels, minVal, maxVal, numThreads );
 		MorphologyUtils.subAAB( closed, source, numThreads );
@@ -262,7 +262,7 @@ public class BlackTopHat
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
 	 */
-	public static < T extends RealType< T > > void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Closing.close( source, target, strels, numThreads );
 		MorphologyUtils.subAAB2( target, source, numThreads );
@@ -321,7 +321,7 @@ public class BlackTopHat
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		Closing.close( source, target, strels, minVal, maxVal, numThreads );
 		MorphologyUtils.subAAB2( target, source, numThreads );
@@ -452,7 +452,7 @@ public class BlackTopHat
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		// Prepare tmp holder
 		final T minVal = MorphologyUtils.createVariable( source, interval );
@@ -514,7 +514,7 @@ public class BlackTopHat
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape> strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		// Prepare tmp holder
 		final ImgFactory< T > factory = Util.getSuitableImgFactory( interval, minVal );

--- a/src/main/java/net/imglib2/algorithm/morphology/Closing.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Closing.java
@@ -77,7 +77,7 @@ public class Closing
 	 * @return an {@link Img} of the same type and same dimensions that of the
 	 *         source.
 	 */
-	public static final < T extends RealType< T >> Img< T > close( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static final < T extends RealType< T >> Img< T > close( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final Img< T > dilated = Dilation.dilate( source, strels, numThreads );
 		final Img< T > eroded = Erosion.erode( dilated, strels, numThreads );
@@ -124,7 +124,7 @@ public class Closing
 	 * @return an {@link Img} of the same type and same dimensions that of the
 	 *         source.
 	 */
-	public static final < T extends Type< T > & Comparable< T > > Img< T > close( final Img< T > source, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static final < T extends Type< T > & Comparable< T > > Img< T > close( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		final Img< T > dilated = Dilation.dilate( source, strels, minVal, numThreads );
 		final Img< T > eroded = Erosion.erode( dilated, strels, maxVal, numThreads );
@@ -239,7 +239,7 @@ public class Closing
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
 	 */
-	public static < T extends RealType< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T maxVal = MorphologyUtils.createVariable( source, target );
 		maxVal.setReal( maxVal.getMaxValue() );
@@ -301,7 +301,7 @@ public class Closing
 	 *            the type of the source and the result. Must extends
 	 *            {@code Compparable}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		// Create temp image
 		final ImgFactory< T > factory = Util.getSuitableImgFactory( target, maxVal );
@@ -456,7 +456,7 @@ public class Closing
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T > > void closeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void closeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T maxVal = MorphologyUtils.createVariable( source, interval );
 		maxVal.setReal( maxVal.getMaxValue() );
@@ -514,7 +514,7 @@ public class Closing
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends Comparable}.
 	 */
-	public static < T extends Type< T > & Comparable< T >> void closeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T >> void closeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{

--- a/src/main/java/net/imglib2/algorithm/morphology/Dilation.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Dilation.java
@@ -87,7 +87,7 @@ public class Dilation
 	 *            a sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends RealType< T > > Img< T > dilate( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > Img< T > dilate( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -138,7 +138,7 @@ public class Dilation
 	 *            a sub-type of {@code T extends Comparable & Type}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > > Img< T > dilate( final Img< T > source, final List< Shape > strels, final T minVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > Img< T > dilate( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -260,7 +260,7 @@ public class Dilation
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
 	 */
-	public static < T extends RealType< T >> void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T minVal = MorphologyUtils.createVariable( source, target );
 		minVal.setReal( minVal.getMinValue() );
@@ -317,7 +317,7 @@ public class Dilation
 	 *            the type of the source image and the dilation result. Must be
 	 *            a sub-type of {@code T extends Comparable & Type}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T minVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final int numThreads )
 	{
 		if ( strels.isEmpty() ) { return; }
 		if ( strels.size() == 1 )
@@ -608,7 +608,7 @@ public class Dilation
 	 *            a sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, possibly of larger dimensions than the source.
 	 */
-	public static < T extends RealType< T > > Img< T > dilateFull( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > Img< T > dilateFull( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -672,7 +672,7 @@ public class Dilation
 	 *            a sub-type of {@code T extends Comparable & Type}.
 	 * @return a new {@link Img}, possibly of larger dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > > Img< T > dilateFull( final Img< T > source, final List< Shape > strels, final T minVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > Img< T > dilateFull( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -833,7 +833,7 @@ public class Dilation
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T > > void dilateInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void dilateInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{
@@ -887,7 +887,7 @@ public class Dilation
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends Comparable & Type}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void dilateInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final T minVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void dilateInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final T minVal, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{

--- a/src/main/java/net/imglib2/algorithm/morphology/Erosion.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Erosion.java
@@ -87,7 +87,7 @@ public class Erosion
 	 *            sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends RealType< T > > Img< T > erode( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > Img< T > erode( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -138,7 +138,7 @@ public class Erosion
 	 *            sub-type of {@code T extends Comparable & Type}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > > Img< T > erode( final Img< T > source, final List< Shape > strels, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > Img< T > erode( final Img< T > source, final List< ? extends Shape > strels, final T maxVal, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -260,7 +260,7 @@ public class Erosion
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
 	 */
-	public static < T extends RealType< T >> void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T maxVal = MorphologyUtils.createVariable( source, target );
 		maxVal.setReal( maxVal.getMaxValue() );
@@ -317,7 +317,7 @@ public class Erosion
 	 *            the type of the source image and the erosion result. Must be a
 	 *            sub-type of {@code T extends Comparable & Type}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T maxVal, final int numThreads )
 	{
 		if ( strels.isEmpty() ) { return; }
 		if ( strels.size() == 1 )
@@ -608,7 +608,7 @@ public class Erosion
 	 *            sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, possibly of larger dimensions than the source.
 	 */
-	public static < T extends RealType< T > > Img< T > erodeFull( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > Img< T > erodeFull( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -672,7 +672,7 @@ public class Erosion
 	 *            sub-type of {@code T extends Comparable & Type}.
 	 * @return a new {@link Img}, possibly of larger dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > > Img< T > erodeFull( final Img< T > source, final List< Shape > strels, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > Img< T > erodeFull( final Img< T > source, final List< ? extends Shape > strels, final T maxVal, final int numThreads )
 	{
 		Img< T > target = source;
 		for ( final Shape strel : strels )
@@ -833,7 +833,7 @@ public class Erosion
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T > > void erodeInPlace( final RandomAccessible< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void erodeInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{
@@ -887,7 +887,7 @@ public class Erosion
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends Comparable & Type}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void erodeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void erodeInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final T maxVal, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{

--- a/src/main/java/net/imglib2/algorithm/morphology/Opening.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Opening.java
@@ -84,7 +84,7 @@ public class Opening
 	 * @return an {@link Img} of the same type and same dimensions that of the
 	 *         source.
 	 */
-	public static final < T extends RealType< T >> Img< T > open( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static final < T extends RealType< T >> Img< T > open( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final Img< T > eroded = Erosion.erode( source, strels, numThreads );
 		final Img< T > dilated = Dilation.dilate( eroded, strels, numThreads );
@@ -131,7 +131,7 @@ public class Opening
 	 * @return an {@link Img} of the same type and same dimensions that of the
 	 *         source.
 	 */
-	public static final < T extends Type< T > & Comparable< T > > Img< T > open( final Img< T > source, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static final < T extends Type< T > & Comparable< T > > Img< T > open( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		final Img< T > eroded = Erosion.erode( source, strels, maxVal, numThreads );
 		final Img< T > dilated = Dilation.dilate( eroded, strels, minVal, numThreads );
@@ -246,7 +246,7 @@ public class Opening
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
 	 */
-	public static < T extends RealType< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T maxVal = MorphologyUtils.createVariable( source, target );
 		maxVal.setReal( maxVal.getMaxValue() );
@@ -308,7 +308,7 @@ public class Opening
 	 *            the type of the source and the result. Must extends
 	 *            {@code Compparable}.
 	 */
-	public static < T extends Type< T > & Comparable< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		// Create temp image
 		final ImgFactory< T > factory = Util.getSuitableImgFactory( target, maxVal );
@@ -463,7 +463,7 @@ public class Opening
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T > > void openInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T > > void openInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		final T maxVal = MorphologyUtils.createVariable( source, interval );
 		maxVal.setReal( maxVal.getMaxValue() );
@@ -521,7 +521,7 @@ public class Opening
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends Comparable}.
 	 */
-	public static < T extends Type< T > & Comparable< T >> void openInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T >> void openInPlace( final RandomAccessibleInterval< T > source, final Interval interval, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		for ( final Shape strel : strels )
 		{

--- a/src/main/java/net/imglib2/algorithm/morphology/TopHat.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/TopHat.java
@@ -90,7 +90,7 @@ public class TopHat
 	 *            sub-type of {@code T extends RealType}.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends RealType< T >> Img< T > topHat( final Img< T > source, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> Img< T > topHat( final Img< T > source, final List< ? extends Shape > strels, final int numThreads )
 	{
 		if ( strels.isEmpty() ) { return source; }
 		final Img< T > opened = Opening.open( source, strels, numThreads );
@@ -142,7 +142,7 @@ public class TopHat
 	 *            themselves and to subtract them.
 	 * @return a new {@link Img}, of same dimensions than the source.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T > > Img< T > topHat( final Img< T > source, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T > > Img< T > topHat( final Img< T > source, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		final Img< T > opened = Opening.open( source, strels, minVal, maxVal, numThreads );
 		MorphologyUtils.subABA( opened, source, numThreads );
@@ -265,7 +265,7 @@ public class TopHat
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
 	 */
-	public static < T extends RealType< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
 		Opening.open( source, target, strels, numThreads );
 		MorphologyUtils.subBAB( source, target, numThreads );
@@ -326,7 +326,7 @@ public class TopHat
 	 *            because we want to be able to compare pixels between
 	 *            themselves and to subtract them.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		Opening.open( source, target, strels, minVal, maxVal, numThreads );
 		MorphologyUtils.subBAB( source, target, numThreads );
@@ -460,7 +460,7 @@ public class TopHat
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
 	 */
-	public static < T extends RealType< T >> void topHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< Shape > strels, final int numThreads )
+	public static < T extends RealType< T >> void topHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
 		// Prepare tmp holder
 		final T minVal = MorphologyUtils.createVariable( source, interval );
@@ -523,7 +523,7 @@ public class TopHat
 	 *            because we want to be able to compare pixels between
 	 *            themselves and to subtract them.
 	 */
-	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< Shape > strels, final T minVal, final T maxVal, final int numThreads )
+	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
 		// Prepare tmp holder
 		final ImgFactory< T > factory = Util.getSuitableImgFactory( interval, minVal );


### PR DESCRIPTION
This PR refactors all morphology methods taking a `List< Shape >` as input (they now take a `List< ? extends Shape >`), allowing for wider input sets while maintaining compile-time and runtime safety. This is especially useful for imagej-ops, since the wildcard generic allows a wider query of (**safe**) Op requests to match wrapper ops for these methods. 