### PR TITLE
ImgMath blockread and offset

### DIFF
--- a/src/main/java/net/imglib2/algorithm/math/Add.java
+++ b/src/main/java/net/imglib2/algorithm/math/Add.java
@@ -23,14 +23,21 @@ public final class Add extends ABinaryFunction
 	}
 
 	@Override
-	public < O extends RealType< O > > Addition< O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Addition< O >( tmp.copy(),
-				this.a.reInit( tmp, bindings, converter, imgSources ),
-				this.b.reInit( tmp, bindings, converter, imgSources ) );
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources ),
+	             			 b = this.b.reInit( tmp, bindings, converter, imgSources );
+
+		// Optimization: remove null ops
+		if ( a.isZero() )
+			return b;
+		if ( b.isZero() )
+			return a;
+				
+		return new Addition< O >( tmp.copy(), a, b );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/AndLogical.java
+++ b/src/main/java/net/imglib2/algorithm/math/AndLogical.java
@@ -1,0 +1,42 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.algorithm.math.abstractions.ABinaryFunction;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.LogicalAnd;
+import net.imglib2.algorithm.math.execution.LogicalAndBoolean;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class AndLogical extends ABinaryFunction
+{	
+	public AndLogical( final Object c1, final Object c2 )
+	{
+		super( c1, c2 );
+	}
+	
+	public AndLogical( final Object... c )
+	{
+		super( c );
+	}
+	
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources );
+		final OFunction< O > b = this.b.reInit( tmp, bindings, converter, imgSources );
+	
+		
+		return a instanceof ABooleanFunction< ? > && b instanceof ABooleanFunction< ? > ?
+			new LogicalAndBoolean< O >( tmp.createVariable(), a, b )
+			: new LogicalAnd< O >( tmp.createVariable(), a, b );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/BlockRead.java
+++ b/src/main/java/net/imglib2/algorithm/math/BlockRead.java
@@ -1,6 +1,7 @@
 package net.imglib2.algorithm.math;
 
 import java.util.Map;
+import java.util.stream.LongStream;
 
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.math.abstractions.IFunction;
@@ -54,6 +55,17 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 		this.signs = BlockRead.signsArray( src );
 		//for (int i=0; i<signs.length; ++i)
 		//	System.out.println("signs[" + i + "] = " + signs[i]);
+	}
+	
+	/**
+	 * A block centered on a particular pixel.
+	 * 
+	 * @param src A {@code RandomAccessible} such as an @{code IntegralImg}, presumably a {@code RandomAccessibleInterval} that was extended with an {@code OutOfBounds} strategy.
+	 * @param blockRadius Half of the length of the side of the block in every dimension.
+	 */
+	public BlockRead( final RandomAccessible< I > src, final long blockRadius )
+	{
+		this( src, LongStream.generate( () -> blockRadius ).limit( src.numDimensions() ).toArray() );
 	}
 	
 	static public byte[] signsArray( final RandomAccessible< ? > src )

--- a/src/main/java/net/imglib2/algorithm/math/BlockRead.java
+++ b/src/main/java/net/imglib2/algorithm/math/BlockRead.java
@@ -1,12 +1,14 @@
 package net.imglib2.algorithm.math;
 
 import java.util.Map;
+
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
 import net.imglib2.algorithm.math.abstractions.ViewableFunction;
 import net.imglib2.algorithm.math.execution.BlockReading;
+import net.imglib2.algorithm.math.execution.BlockReadingDirect;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;
@@ -28,26 +30,30 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 	/**
 	 * A block centered on a particular pixel.
 	 * 
-	 * @param src
-	 * @param dimensions The length of the sides of the block.
+	 * @param src A {@code RandomAccessible} such as an @{code IntegralImg}, presumably a {@code RandomAccessibleInterval} that was extended with an {@code OutOfBounds} strategy.
+	 * @param blockRadius Array of half of the length of each side of the block.
 	 */
-	public BlockRead( final RandomAccessible< I > src, final long[] dimensions )
+	public BlockRead( final RandomAccessible< I > src, final long[] blockRadius )
 	{
 		this.src = src;
-		this.corners = new long[ ( int )Math.pow( 2,  dimensions.length ) ][ dimensions.length ];
+		this.corners = new long[ ( int )Math.pow( 2,  blockRadius.length ) ][ blockRadius.length ];
 
 		// All possible combinations to define all corners, sorted with lower dimensions being the slower-moving,
 		// following Gray code (see https://en.wikipedia.org/wiki/Gray_code )
-		for (int d = 0; d < dimensions.length; ++ d )
+		for (int d = 0; d < src.numDimensions(); ++d )
 		{
-			final long half = dimensions[ d ] / 2;
-			final int cycle = corners.length / ( int )Math.pow( 2, d );
+			final int cycle = corners.length / ( int )Math.pow( 2, d + 1 );
+			long inc = blockRadius[ d ];
 			for (int i = 0; i < corners.length; ++i )
 			{
-				corners[ i ][ d ] = 0 == i % cycle ? -half : half;
+				if ( 0 == i % cycle) inc *= -1;
+				corners[ i ][ d ] = inc;
+				System.out.println("corners[" + i + "][" + d + "] = " + corners[i][d]);
 			}
 		}
 		this.signs = BlockRead.signsArray( src );
+		for (int i=0; i<signs.length; ++i)
+			System.out.println("signs[" + i + "] = " + signs[i]);
 	}
 	
 	static public byte[] signsArray( final RandomAccessible< ? > src )
@@ -61,6 +67,7 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 			//                          -C( x1,y2 )
 			//                          -C( x2,y1 )
 			//                          +C( x2,y2 )
+			// Corners as: (x1, y1), (x1, y2), (x2, y1), (x2, y2)
 			return new byte[]{ 1, -1, -1, 1 };
 		case 3:
 			// 3D: S( (x1,y1,z1) to (x2,y2,z2) ) =  - C( x1, y1, z1 )
@@ -76,10 +83,15 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 			// There's a clear pattern, but I can't find the time now to break through it
 			// Must re-read Tapias 2011 doi:10.1016/j.patrec.2010.10.007
 			// for the use of the Mobius function for determining the sign
-			throw new UnsupportedOperationException( "Sorry, numDimensions > 3 not supported yet. " );
+			throw new UnsupportedOperationException( "Sorry, numDimensions " + src.numDimensions() + " not supported yet." );
 		}
 	}
 	
+	/**
+	 * 
+	 * @param src
+	 * @param corners In coordinate moves relative to a pixel's location.
+	 */
 	public BlockRead( final RandomAccessible< I > src, final long[][] corners )
 	{
 		this.src = src;
@@ -87,13 +99,16 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 		this.signs = BlockRead.signsArray( src );
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public < O extends RealType< O > > BlockReading< I, O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
+		if ( tmp.getClass() == src.randomAccess().get().getClass() )
+			return new BlockReadingDirect< O >( tmp.copy(), ( RandomAccessible< O > )this.src, this.corners, this.signs );
 		return new BlockReading< I, O >(
 				tmp.copy(),
 				converter,

--- a/src/main/java/net/imglib2/algorithm/math/BlockRead.java
+++ b/src/main/java/net/imglib2/algorithm/math/BlockRead.java
@@ -48,12 +48,12 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 			{
 				if ( 0 == i % cycle) inc *= -1;
 				corners[ i ][ d ] = inc;
-				System.out.println("corners[" + i + "][" + d + "] = " + corners[i][d]);
+				//System.out.println("corners[" + i + "][" + d + "] = " + corners[i][d]);
 			}
 		}
 		this.signs = BlockRead.signsArray( src );
-		for (int i=0; i<signs.length; ++i)
-			System.out.println("signs[" + i + "] = " + signs[i]);
+		//for (int i=0; i<signs.length; ++i)
+		//	System.out.println("signs[" + i + "] = " + signs[i]);
 	}
 	
 	static public byte[] signsArray( final RandomAccessible< ? > src )

--- a/src/main/java/net/imglib2/algorithm/math/BlockRead.java
+++ b/src/main/java/net/imglib2/algorithm/math/BlockRead.java
@@ -1,0 +1,109 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.math.abstractions.IFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
+import net.imglib2.algorithm.math.abstractions.ViewableFunction;
+import net.imglib2.algorithm.math.execution.BlockReading;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * Intended for reading cuboid blocks out of an integral image.
+ * 
+ * @author Albert Cardona
+ *
+ * @param <I> The {@code Type} of the {@code RandomAccessible} from which to read blocks.
+ */
+public final class BlockRead< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
+{
+	final private RandomAccessible< I > src;
+	final private long[][] corners;
+	final private byte[] signs;
+	
+	/**
+	 * A block centered on a particular pixel.
+	 * 
+	 * @param src
+	 * @param dimensions The length of the sides of the block.
+	 */
+	public BlockRead( final RandomAccessible< I > src, final long[] dimensions )
+	{
+		this.src = src;
+		this.corners = new long[ ( int )Math.pow( 2,  dimensions.length ) ][ dimensions.length ];
+
+		// All possible combinations to define all corners, sorted with lower dimensions being the slower-moving,
+		// following Gray code (see https://en.wikipedia.org/wiki/Gray_code )
+		for (int d = 0; d < dimensions.length; ++ d )
+		{
+			final long half = dimensions[ d ] / 2;
+			final int cycle = corners.length / ( int )Math.pow( 2, d );
+			for (int i = 0; i < corners.length; ++i )
+			{
+				corners[ i ][ d ] = 0 == i % cycle ? -half : half;
+			}
+		}
+		this.signs = BlockRead.signsArray( src );
+	}
+	
+	static public byte[] signsArray( final RandomAccessible< ? > src )
+	{
+		switch ( src.numDimensions() )
+		{
+		case 1:
+			return new byte[]{ -1, 1 };
+		case 2:
+			// 2D: S( (x1,y1), (x2,y2) = C( x1,y1 )
+			//                          -C( x1,y2 )
+			//                          -C( x2,y1 )
+			//                          +C( x2,y2 )
+			return new byte[]{ 1, -1, -1, 1 };
+		case 3:
+			// 3D: S( (x1,y1,z1) to (x2,y2,z2) ) =  - C( x1, y1, z1 )
+			//                                      + C( x1, y1, z2 )
+			//                                      + C( x1, y2, z1 )
+			//                                      - C( x1, y2, z2 )
+			//                                      + C( x2, y1, z1 )
+			//                                      - C( x2, y1, z2 )
+			//                                      - C( x2, y2, z1 )
+			//                                      + C( x2, y2, z2 )
+			return new byte[]{ -1, 1, 1, -1, 1, -1, -1, 1 };
+		default:
+			// There's a clear pattern, but I can't find the time now to break through it
+			// Must re-read Tapias 2011 doi:10.1016/j.patrec.2010.10.007
+			// for the use of the Mobius function for determining the sign
+			throw new UnsupportedOperationException( "Sorry, numDimensions > 3 not supported yet. " );
+		}
+	}
+	
+	public BlockRead( final RandomAccessible< I > src, final long[][] corners )
+	{
+		this.src = src;
+		this.corners = corners;
+		this.signs = BlockRead.signsArray( src );
+	}
+
+	@Override
+	public < O extends RealType< O > > BlockReading< I, O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		return new BlockReading< I, O >(
+				tmp.copy(),
+				converter,
+				this.src,
+				this.corners,
+				this.signs );
+	}
+	
+	public RandomAccessible< I > getRandomAccessible()
+	{
+		return this.src;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/BlockReadSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/BlockReadSource.java
@@ -8,7 +8,7 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
 import net.imglib2.algorithm.math.abstractions.ViewableFunction;
-import net.imglib2.algorithm.math.execution.BlockReading;
+import net.imglib2.algorithm.math.execution.BlockReadingSource;
 import net.imglib2.algorithm.math.execution.BlockReadingDirect;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Variable;
@@ -22,7 +22,7 @@ import net.imglib2.type.numeric.RealType;
  *
  * @param <I> The {@code Type} of the {@code RandomAccessible} from which to read blocks.
  */
-public final class BlockRead< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
+public final class BlockReadSource< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly< I >
 {
 	final private RandomAccessible< I > src;
 	final private long[][] corners;
@@ -34,7 +34,7 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 	 * @param src A {@code RandomAccessible} such as an @{code IntegralImg}, presumably a {@code RandomAccessibleInterval} that was extended with an {@code OutOfBounds} strategy.
 	 * @param blockRadius Array of half of the length of each side of the block.
 	 */
-	public BlockRead( final RandomAccessible< I > src, final long[] blockRadius )
+	public BlockReadSource( final RandomAccessible< I > src, final long[] blockRadius )
 	{
 		this.src = src;
 		this.corners = new long[ ( int )Math.pow( 2,  blockRadius.length ) ][ blockRadius.length ];
@@ -52,7 +52,7 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 				//System.out.println("corners[" + i + "][" + d + "] = " + corners[i][d]);
 			}
 		}
-		this.signs = BlockRead.signsArray( src );
+		this.signs = BlockReadSource.signsArray( src );
 		//for (int i=0; i<signs.length; ++i)
 		//	System.out.println("signs[" + i + "] = " + signs[i]);
 	}
@@ -63,7 +63,7 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 	 * @param src A {@code RandomAccessible} such as an @{code IntegralImg}, presumably a {@code RandomAccessibleInterval} that was extended with an {@code OutOfBounds} strategy.
 	 * @param blockRadius Half of the length of the side of the block in every dimension.
 	 */
-	public BlockRead( final RandomAccessible< I > src, final long blockRadius )
+	public BlockReadSource( final RandomAccessible< I > src, final long blockRadius )
 	{
 		this( src, LongStream.generate( () -> blockRadius ).limit( src.numDimensions() ).toArray() );
 	}
@@ -104,11 +104,11 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 	 * @param src
 	 * @param corners In coordinate moves relative to a pixel's location.
 	 */
-	public BlockRead( final RandomAccessible< I > src, final long[][] corners )
+	public BlockReadSource( final RandomAccessible< I > src, final long[][] corners )
 	{
 		this.src = src;
 		this.corners = corners;
-		this.signs = BlockRead.signsArray( src );
+		this.signs = BlockReadSource.signsArray( src );
 	}
 
 	@SuppressWarnings("unchecked")
@@ -121,7 +121,7 @@ public final class BlockRead< I extends RealType< I > > extends ViewableFunction
 	{
 		if ( tmp.getClass() == src.randomAccess().get().getClass() )
 			return new BlockReadingDirect< O >( tmp.copy(), ( RandomAccessible< O > )this.src, this.corners, this.signs );
-		return new BlockReading< I, O >(
+		return new BlockReadingSource< I, O >(
 				tmp.copy(),
 				converter,
 				this.src,

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -152,7 +152,7 @@ public class Compute
 	 */
 	public < O extends RealType< O > > RandomAccessibleInterval< O > into( final RandomAccessibleInterval< O > target )
 	{
-		return this.into( target, null );
+		return this.into( target, null, target.randomAccess().get().createVariable(), null );
 	}
 	
 	/**
@@ -175,6 +175,14 @@ public class Compute
 			)
 	{
 		return into( target, inConverter, target.randomAccess().get().createVariable(), null );
+	}
+	
+	public < O extends RealType< O >, C extends RealType< C > > RandomAccessibleInterval< O > into(
+			final RandomAccessibleInterval< O > target,
+			final C computingType
+			)
+	{
+		return into( target, null, computingType, null );
 	}
 
 	public < O extends RealType< O >, C extends RealType< C > > RandomAccessibleInterval< O > into(

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -313,7 +313,7 @@ public class Compute
 	
 	public < O extends RealType< O >, C extends RealType< C > > RandomAccessibleInterval< O > view(
 			final Interval interval,
-			final Converter< ? extends RealType< ? >, C > inConverter,
+			final Converter< RealType< ? >, C > inConverter,
 			final C computingType,
 			final O outputType,
 			final Converter< C, O > outConverter )
@@ -329,13 +329,13 @@ public class Compute
 			@Override
 			public RandomAccess< O > randomAccess()
 			{
-				return Compute.this.randomAccess();
+				return Compute.this.randomAccess( inConverter, computingType, outputType, outConverter );
 			}
 
 			@Override
 			public RandomAccess< O > randomAccess( final Interval interval )
 			{
-				return Compute.this.randomAccess();
+				return this.randomAccess();
 			}
 		}, interval );
 	}

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
@@ -67,10 +68,23 @@ public class Compute
 	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > & NativeType< C > > RandomAccessibleInterval< O >
 	intoArrayImg( final C computeType, final O outputType )
 	{
-		final RandomAccessibleInterval< ? > rai = Util.findImg( operation ).iterator().next();
-		final ArrayImg< O, ? > target = new ArrayImgFactory< O >( outputType ).create( rai );
-		this.params.compatible_iteration_order = Util.compatibleIterationOrder( Arrays.asList( rai, target ) );
-		return this.into( new ArrayImgFactory< O >( outputType ).create( rai ), null, computeType, null );
+		final Set< RandomAccessibleInterval< ? > > imgs = Util.findImg( operation );
+		final Interval interval;
+		final ArrayList< RandomAccessibleInterval< ? > > ls = new ArrayList<>();
+		if ( imgs.isEmpty() )
+		{
+			interval = Util.findFirstInterval( operation );
+			this.params.compatible_iteration_order = true; // no images present, only RandomAccessible like e.g. KDTreeSource
+		}
+		else
+		{
+			interval = imgs.iterator().next();
+			ls.addAll( imgs );
+		}
+		final ArrayImg< O, ? > target = new ArrayImgFactory< O >( outputType ).create( interval );
+		ls.add( target );
+		this.params.compatible_iteration_order = Util.compatibleIterationOrder( ls );
+		return this.into( target, null, computeType, null );
 	}
 	
 	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > > RandomAccessibleInterval< O >

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -55,17 +55,18 @@ public class Compute
 		this.params = Compute.validate( this.operation );
 	}
 	
-	public < O extends RealType< O > & NativeType< O > > RandomAccessibleInterval< O >
+	public < O extends RealType< O > & NativeType< O > > ArrayImg< O, ? >
 	intoArrayImg()
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval< O > rai = ( RandomAccessibleInterval< O > )Util.findImg( operation ).iterator().next();
 		final ArrayImg< O, ? > target = new ArrayImgFactory< O >( rai.randomAccess().get().createVariable() ).create( rai );
 		this.params.compatible_iteration_order = Util.compatibleIterationOrder( Arrays.asList( rai, target ) );
-		return this.into( target );
+		this.into( target );
+		return target;
 	}
 	
-	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > & NativeType< C > > RandomAccessibleInterval< O >
+	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > & NativeType< C > > ArrayImg< O, ? >
 	intoArrayImg( final C computeType, final O outputType )
 	{
 		final Set< RandomAccessibleInterval< ? > > imgs = Util.findImg( operation );
@@ -84,10 +85,11 @@ public class Compute
 		final ArrayImg< O, ? > target = new ArrayImgFactory< O >( outputType ).create( interval );
 		ls.add( target );
 		this.params.compatible_iteration_order = Util.compatibleIterationOrder( ls );
-		return this.into( target, null, computeType, null );
+		this.into( target, null, computeType, null );
+		return target;
 	}
 	
-	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > > RandomAccessibleInterval< O >
+	public < O extends RealType< O > & NativeType< O >, C  extends RealType< C > > ArrayImg< O, ? >
 	intoArrayImg( final O outputType )
 	{
 		return intoArrayImg( outputType.createVariable(), outputType );

--- a/src/main/java/net/imglib2/algorithm/math/Compute.java
+++ b/src/main/java/net/imglib2/algorithm/math/Compute.java
@@ -177,6 +177,16 @@ public class Compute
 		return into( target, inConverter, target.randomAccess().get().createVariable(), null );
 	}
 
+	public < O extends RealType< O >, C extends RealType< C > > RandomAccessibleInterval< O > into(
+			final RandomAccessibleInterval< O > target,
+			Converter< RealType< ? >, C > inConverter,
+			final C computingType,
+			Converter< C, O > outConverter
+			)
+	{
+		return into( target, inConverter, computingType, outConverter, false );
+	}
+
 	/**
 	 * Execute the mathematical operations and store the result into the given {@code RandomAccessibleInterval}.
 	 * Takes into account whether all images involved in the computation are iterable in a compatible way.
@@ -197,6 +207,8 @@ public class Compute
 	 *                 when the {@code computingType} equal the {@code Type} of the {@code target}, and a generic
 	 *                 {@code RealType} converter that uses floating-point values (with {@code RealType#setReal(double)})
 	 *                 created with {@code Util#genericRealTypeConverter()} is used.
+	 *                 
+	 * @param printHierarchy Emits to stdout the hierarchy of {@code OFunction} types.
 	 * 
 	 * @return The {@code target}.
 	 */
@@ -205,7 +217,8 @@ public class Compute
 			final RandomAccessibleInterval< O > target,
 			Converter< RealType< ? >, C > inConverter,
 			final C computingType,
-			Converter< C, O > outConverter
+			Converter< C, O > outConverter,
+			final boolean printHierarchy
 			)
 	{
 		if ( null == inConverter )
@@ -221,6 +234,9 @@ public class Compute
 				computingType,
 				new HashMap< String, LetBinding< C > >(),
 				inConverter, null );
+		
+		if ( printHierarchy )
+			System.out.println( Util.hierarchy( f ) );
 		
 		if ( are_same_type )
 		{

--- a/src/main/java/net/imglib2/algorithm/math/Div.java
+++ b/src/main/java/net/imglib2/algorithm/math/Div.java
@@ -24,14 +24,18 @@ public final class Div extends ABinaryFunction
 	}
 
 	@Override
-	public < O extends RealType< O > > Division< O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Division< O >( tmp.copy(),
-				this.a.reInit( tmp, bindings, converter, imgSources ),
-				this.b.reInit( tmp, bindings, converter, imgSources ) );
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources ),
+					         b = this.b.reInit( tmp, bindings, converter, imgSources );
+		
+		if ( a.isZero() || b.isOne() )
+			return a;
+		
+		return new Division< O >( tmp.copy(), a, b );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -6,6 +6,7 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.Util;
+import net.imglib2.algorithm.math.abstractions.ViewableFunction;
 import net.imglib2.converter.Converter;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
@@ -115,6 +116,28 @@ public class ImgMath
 	static public final < O extends NativeType< O > & RealType< O > > RandomAccessibleInterval< O > computeIntoArrayImg( final IFunction operation )
 	{
 		return compute( operation ).intoArrayImg();
+	}
+	
+	/**
+	 * Almost all {@code IFunction} are also {@code ViewableFunction}. 
+	 * 
+	 * @param operation
+	 * @return
+	 */
+	static public final < O extends RealType< O > > RandomAccessibleInterval< O > view( final ViewableFunction operation )
+	{
+		return operation.view();
+	}
+	
+	/**
+	 * Almost all {@code IFunction} are also {@code ViewableFunction}. 
+	 * 
+	 * @param operation
+	 * @return
+	 */
+	static public final RandomAccessibleInterval< FloatType > viewFloats( final ViewableFunction operation )
+	{
+		return operation.view( new FloatType() );
 	}
 	
 	static public final Add add( final Object o1, final Object o2 )

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -351,19 +351,19 @@ public class ImgMath
 		return new NumberSource( number );
 	}
 	
-	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[] radius )
+	static public final < T extends RealType< T > > BlockReadSource< T > block( final RandomAccessible< T > src, final long[] radius )
 	{
-		return new BlockRead< T >( src, radius );
+		return new BlockReadSource< T >( src, radius );
 	}
 	
-	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long radius )
+	static public final < T extends RealType< T > > BlockReadSource< T > block( final RandomAccessible< T > src, final long radius )
 	{
-		return new BlockRead< T >( src, radius );
+		return new BlockReadSource< T >( src, radius );
 	}
 	
-	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[][] corners )
+	static public final < T extends RealType< T > > BlockReadSource< T > block( final RandomAccessible< T > src, final long[][] corners )
 	{
-		return new BlockRead< T >( src, corners );
+		return new BlockReadSource< T >( src, corners );
 	}
 	
 	static public final < T extends RealType< T > > RandomAccessibleSource< T > offset( final RandomAccessible< T > src, final long[] offset )

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -328,9 +328,14 @@ public class ImgMath
 		return new NumberSource( number );
 	}
 	
-	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[] dimensions )
+	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[] radius )
 	{
-		return new BlockRead< T >( src, dimensions );
+		return new BlockRead< T >( src, radius );
+	}
+	
+	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long radius )
+	{
+		return new BlockRead< T >( src, radius );
 	}
 	
 	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[][] corners )

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -87,7 +87,7 @@ public class ImgMath
 		return compute( img( src ) );
 	}
 	
-	static public final RandomAccessibleInterval< FloatType > computeIntoFloat( final IFunction operation )
+	static public final RandomAccessibleInterval< FloatType > computeIntoFloats( final IFunction operation )
 	{
 		return new Compute( operation ).into( new ArrayImgFactory< FloatType >( new FloatType() ).create( Util.findImg( operation ).iterator().next() ) );
 	}

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -190,19 +190,9 @@ public class ImgMath
 		return new Pow( o1, o2 );
 	}
 	
-	static public final Pow power( final Object... obs )
-	{
-		return new Pow( obs );
-	}
-	
 	static public final Pow power( final Object o1, final Object o2 )
 	{
 		return new Pow( o1, o2 );
-	}
-	
-	static public final Pow pow( final Object... obs )
-	{
-		return new Pow( obs );
 	}
 
 	static public final Max max( final Object o1, final Object o2 )

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -137,6 +137,11 @@ public class ImgMath
 		return new Sub( obs );
 	}
 	
+	static public final Minus minus( final Object o1 )
+	{
+		return new Minus( o1 );
+	}
+	
 	static public final Mul mul( final Object o1, final Object o2 )
 	{
 		return new Mul( o1, o2 );

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -1,5 +1,8 @@
 package net.imglib2.algorithm.math;
 
+import net.imglib2.Interval;
+import net.imglib2.KDTree;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.Util;
@@ -77,6 +80,11 @@ public class ImgMath
 	static public final Compute compute( final IFunction operation )
 	{
 		return new Compute( operation );
+	}
+	
+	static public final < I extends RealType< I > > Compute compute( final RandomAccessibleInterval< I > src )
+	{
+		return compute( img( src ) );
 	}
 	
 	static public final RandomAccessibleInterval< FloatType > computeIntoFloat( final IFunction operation )
@@ -304,8 +312,51 @@ public class ImgMath
 		return new ImgSource< T >( rai );
 	}
 	
+	/** Synonym of {@code img(RandomAccessibleInterval)}, given that {@code img} is a widely used variable name. */
+	static public final < T extends RealType< T > > ImgSource< T > intervalSource( final RandomAccessibleInterval< T > rai )
+	{
+		return new ImgSource< T >( rai );
+	}
+	
 	static public final NumberSource number( final Number number )
 	{
 		return new NumberSource( number );
+	}
+	
+	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[] dimensions )
+	{
+		return new BlockRead< T >( src, dimensions );
+	}
+	
+	static public final < T extends RealType< T > > BlockRead< T > block( final RandomAccessible< T > src, final long[][] corners )
+	{
+		return new BlockRead< T >( src, corners );
+	}
+	
+	static public final < T extends RealType< T > > RandomAccessibleSource< T > offset( final RandomAccessible< T > src, final long[] offset )
+	{
+		return new RandomAccessibleSource< T >( src, offset );
+	}
+	
+	static public final < T extends RealType< T > > IFunction source( final RandomAccessible< T > src )
+	{
+		if ( src instanceof RandomAccessibleInterval< ? > )
+			return intervalSource( ( RandomAccessibleInterval< T > )src );
+		return new RandomAccessibleSource< T >( src );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final KDTree< T > kdtree, final double radius )
+	{
+		return new KDTreeSource< T >( kdtree, radius );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final KDTree< T > kdtree, final double radius, final Object outside )
+	{
+		return new KDTreeSource< T >( kdtree, radius, outside );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final KDTree< T > kdtree, final double radius, final Object outside, final Interval interval )
+	{
+		return new KDTreeSource< T >( kdtree, radius, outside, interval );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -335,6 +335,41 @@ public class ImgMath
 		return new Else( o );
 	}
 	
+	static public final AndLogical AND( final Object o1, final Object o2 )
+	{
+		return new AndLogical( o1, o2 );
+	}
+	
+	static public final AndLogical AND( final Object... o )
+	{
+		return new AndLogical( o );
+	}
+	
+	static public final OrLogical OR( final Object o1, final Object o2 )
+	{
+		return new OrLogical( o1, o2 );
+	}
+	
+	static public final OrLogical OR( final Object... o )
+	{
+		return new OrLogical( o );
+	}
+	
+	static public final XorLogical XOR( final Object o1, final Object o2 )
+	{
+		return new XorLogical( o1, o2 );
+	}
+	
+	static public final XorLogical XOR( final Object... o )
+	{
+		return new XorLogical( o );
+	}
+	
+	static public final NotLogical NOT( final Object o )
+	{
+		return new NotLogical( o );
+	}
+	
 	static public final < T extends RealType< T > > ImgSource< T > img( final RandomAccessibleInterval< T > rai )
 	{
 		return new ImgSource< T >( rai );
@@ -397,4 +432,5 @@ public class ImgMath
 	{
 		return new KDTreeSource< T >( kdtree, radius, outside, interval );
 	}
+
 }

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -371,6 +371,11 @@ public class ImgMath
 		return new RandomAccessibleSource< T >( src, offset );
 	}
 	
+	static public final < T extends RealType< T > > OffsetSource< T > offset( final IFunction f, final long[] offset )
+	{
+		return new OffsetSource< T >( f, offset );
+	}
+	
 	static public final < T extends RealType< T > > IFunction source( final RandomAccessible< T > src )
 	{
 		if ( src instanceof RandomAccessibleInterval< ? > )

--- a/src/main/java/net/imglib2/algorithm/math/ImgMath.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgMath.java
@@ -1,7 +1,10 @@
 package net.imglib2.algorithm.math;
 
+import java.util.List;
+
 import net.imglib2.Interval;
 import net.imglib2.KDTree;
+import net.imglib2.Point;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.math.abstractions.IFunction;
@@ -406,6 +409,36 @@ public class ImgMath
 		if ( src instanceof RandomAccessibleInterval< ? > )
 			return intervalSource( ( RandomAccessibleInterval< T > )src );
 		return new RandomAccessibleSource< T >( src );
+	}
+
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final T value, final double radius )
+	{
+		return new KDTreeSource< T >( positions, value, radius );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final T value, final double radius, final Object outside )
+	{
+		return new KDTreeSource< T >( positions, value, radius, outside );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final T value, final double radius, final Object outside, final Interval interval )
+	{
+		return new KDTreeSource< T >( positions, value, radius, outside, interval );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final List< T > values, final double radius )
+	{
+		return new KDTreeSource< T >( positions, values, radius );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final List< T > values, final double radius, final Object outside )
+	{
+		return new KDTreeSource< T >( positions, values, radius, outside );
+	}
+	
+	static public final < T extends RealType< T > > KDTreeSource< T > gen( final List< Point > positions, final List< T > values, final double radius, final Object outside, final Interval interval )
+	{
+		return new KDTreeSource< T >( positions, values, radius, outside, interval );
 	}
 	
 	static public final < T extends RealType< T > > KDTreeSource< T > gen( final KDTree< T > kdtree, final double radius )

--- a/src/main/java/net/imglib2/algorithm/math/ImgSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/ImgSource.java
@@ -2,9 +2,11 @@ package net.imglib2.algorithm.math;
 
 import java.util.Map;
 
+import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.SourceInterval;
 import net.imglib2.algorithm.math.abstractions.ViewableFunction;
 import net.imglib2.algorithm.math.execution.ImgSourceIterable;
 import net.imglib2.algorithm.math.execution.ImgSourceIterableDirect;
@@ -13,7 +15,7 @@ import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class ImgSource< I extends RealType< I > > extends ViewableFunction implements IFunction
+public class ImgSource< I extends RealType< I > > extends ViewableFunction implements IFunction, SourceInterval
 {
 	private final RandomAccessibleInterval< I > rai;
 
@@ -52,6 +54,11 @@ public class ImgSource< I extends RealType< I > > extends ViewableFunction imple
 	}
 	
 	public RandomAccessibleInterval< I > getRandomAccessibleInterval()
+	{
+		return this.rai;
+	}
+	
+	public Interval getInterval()
 	{
 		return this.rai;
 	}

--- a/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
@@ -1,0 +1,104 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.KDTree;
+import net.imglib2.algorithm.math.abstractions.IFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.SourceInterval;
+import net.imglib2.algorithm.math.execution.KDTreeRadiusSource;
+import net.imglib2.algorithm.math.abstractions.ViewableFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
+
+public class KDTreeSource< I extends RealType< I > > extends ViewableFunction implements IFunction, SourceInterval
+{
+	private final KDTree< I > kdtree;
+	private final double radius;
+	private final I outside;
+	private final Interval interval;
+	
+	public KDTreeSource( final KDTree< I > kdtree, final double radius )
+	{
+		this( kdtree, radius, kdtree.firstElement().createVariable(), null ); // with outside of value zero
+	}
+	
+	public KDTreeSource( final KDTree< I > kdtree, final double radius, final Object outside )
+	{
+		this( kdtree, radius, outside, null );
+	}
+	
+	public KDTreeSource( final KDTree< I > kdtree, final double radius, final Object outside, final Interval interval )
+	{
+		this.kdtree = kdtree;
+		this.radius = radius;
+		final I first = kdtree.firstElement();
+		this.outside = asInputType( first, outside );
+		if ( null == interval )
+		{
+			// Find out the interval from the data
+			final long[] min = new long[ kdtree.numDimensions() ],
+					     max = new long[ kdtree.numDimensions() ];
+			for ( int d = 0; d < kdtree.numDimensions(); ++d )
+			{
+				min[ d ] = ( long )Math.floor( kdtree.realMin( d ) - radius );
+				max[ d ] = ( long )Math.ceil( kdtree.realMax( d ) + radius );
+			}
+			this.interval = new FinalInterval( min, max );
+		}
+		else
+		{
+			this.interval = interval;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static final <I extends RealType< I > > I asInputType( final I first, final Object ob )
+	{
+		if ( first.getClass().isAssignableFrom( ob.getClass() ) )
+			return ( I )ob;
+		final I v = first.createVariable();
+		if ( v instanceof IntegerType< ? > && ( ob instanceof Long || ob instanceof Integer || ob instanceof Short || ob instanceof Byte ) )
+		{
+			( ( IntegerType< ? >)v ).setInteger( ( ( Number )ob ).longValue() );
+			return v;
+		}
+		if ( ob instanceof RealType< ? > )
+		{
+			v.setReal( ( ( RealType< ? > )ob ).getRealDouble() );
+			return v;
+		}
+		if ( ob instanceof Number) // Float or Double or else
+		{
+			v.setReal( ( ( Number )ob ).doubleValue() );
+			return v;
+		}
+		throw new UnsupportedOperationException( "KDTreeSource can't handle " + ob + " as outside value." );
+	}
+
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		return new KDTreeRadiusSource< I, O >( tmp.copy(), converter, this.kdtree, this.radius, this.outside, this.interval );
+	}
+	
+	public KDTree< I > getKDTree()
+	{
+		return this.kdtree;
+	}
+	
+	@Override
+	public Interval getInterval()
+	{
+		return this.interval;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
@@ -38,9 +38,29 @@ public class KDTreeSource< I extends RealType< I > > extends ViewableFunction im
 		this( new KDTree< I >( points.stream().map( ( p ) -> value ).collect( Collectors.toList() ), points ), radius );
 	}
 	
+	public KDTreeSource( final List< Point > points, final I value, final double radius, final Object outside )
+	{
+		this( new KDTree< I >( points.stream().map( ( p ) -> value ).collect( Collectors.toList() ), points ), radius, outside, null );
+	}
+	
+	public KDTreeSource( final List< Point > points, final I value, final double radius, final Object outside, final Interval interval )
+	{
+		this( new KDTree< I >( points.stream().map( ( p ) -> value ).collect( Collectors.toList() ), points ), radius, outside, interval );
+	}
+	
 	public KDTreeSource( final List< Point > points, final List< I > values, final double radius )
 	{
 		this( new KDTree< I >( values, points ), radius );
+	}
+	
+	public KDTreeSource( final List< Point > points, final List< I > values, final double radius, final Object outside )
+	{
+		this( new KDTree< I >( values, points ), radius, outside, null );
+	}
+	
+	public KDTreeSource( final List< Point > points, final List< I > values, final double radius, final Object outside, final Interval interval )
+	{
+		this( new KDTree< I >( values, points ), radius, outside, interval );
 	}
 	
 	public KDTreeSource( final KDTree< I > kdtree, final double radius )

--- a/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/KDTreeSource.java
@@ -1,10 +1,13 @@
 package net.imglib2.algorithm.math;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.KDTree;
+import net.imglib2.Point;
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.abstractions.SourceInterval;
@@ -22,6 +25,23 @@ public class KDTreeSource< I extends RealType< I > > extends ViewableFunction im
 	private final double radius;
 	private final I outside;
 	private final Interval interval;
+
+	/*
+	public KDTreeSource( final Collection< List< Number > > points, final List< I > values, final double radius )
+	{
+		this( new KDTree< I >( values, points.stream().map( ( coords ) -> Point.wrap( coords.stream().mapToLong( Number::longValue ).toArray() ) ).collect( Collectors.toList() ) ), radius );
+	}
+	*/
+	
+	public KDTreeSource( final List< Point > points, final I value, final double radius )
+	{
+		this( new KDTree< I >( points.stream().map( ( p ) -> value ).collect( Collectors.toList() ), points ), radius );
+	}
+	
+	public KDTreeSource( final List< Point > points, final List< I > values, final double radius )
+	{
+		this( new KDTree< I >( values, points ), radius );
+	}
 	
 	public KDTreeSource( final KDTree< I > kdtree, final double radius )
 	{

--- a/src/main/java/net/imglib2/algorithm/math/Minus.java
+++ b/src/main/java/net/imglib2/algorithm/math/Minus.java
@@ -1,0 +1,30 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.algorithm.math.abstractions.AUnaryFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.algorithm.math.execution.ZeroMinus;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public final class Minus extends AUnaryFunction
+{
+	public Minus( final Object o )
+	{
+		super( o );
+	}
+
+	@Override
+	public < O extends RealType< O > > ZeroMinus< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		return new ZeroMinus< O >( tmp.copy(), this.a.reInit( tmp, bindings, converter, imgSources ) );
+	}
+
+}

--- a/src/main/java/net/imglib2/algorithm/math/Mul.java
+++ b/src/main/java/net/imglib2/algorithm/math/Mul.java
@@ -23,14 +23,25 @@ public final class Mul extends ABinaryFunction
 	}
 
 	@Override
-	public < O extends RealType< O > > Multiplication< O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Multiplication< O >( tmp.copy(),
-				this.a.reInit( tmp, bindings, converter, imgSources ),
-				this.b.reInit( tmp, bindings, converter, imgSources ) );
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources ),
+				             b = this.b.reInit( tmp, bindings, converter, imgSources );
+		
+		// Optimization: remove null ops
+		if ( a.isOne() )
+			return b;
+		if ( b.isOne() )
+			return a;
+		if ( a.isZero() )
+			return a;
+		if ( b.isZero() )
+			return b;
+		
+		return new Multiplication< O >( tmp.copy(), a, b );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/NotLogical.java
+++ b/src/main/java/net/imglib2/algorithm/math/NotLogical.java
@@ -1,0 +1,35 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
+import net.imglib2.algorithm.math.abstractions.AUnaryFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.LogicalNot;
+import net.imglib2.algorithm.math.execution.LogicalNotBoolean;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class NotLogical extends AUnaryFunction
+{	
+	public NotLogical( final Object c1 )
+	{
+		super( c1 );
+	}
+	
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources );
+		
+		return a instanceof ABooleanFunction< ? > ?
+			new LogicalNotBoolean< O >( tmp.createVariable(), a )
+			: new LogicalNot< O >( tmp.createVariable(), a );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/NumberSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/NumberSource.java
@@ -4,8 +4,6 @@ import java.util.Map;
 
 import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunction;
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunctionDouble;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.NumericSource;
 import net.imglib2.algorithm.math.execution.Variable;

--- a/src/main/java/net/imglib2/algorithm/math/NumberSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/NumberSource.java
@@ -29,40 +29,4 @@ public final class NumberSource implements IFunction
 	{
 		return new NumericSource< O >( tmp.copy(), this.number );
 	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view()
-	{
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType )
-	{
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType, final Converter< RealType< ? >, O > converter )
-	{
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble()
-	{
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType )
-	{
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType, final Converter< RealType< ? >, O > converter )
-	{
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/OffsetRead.java
+++ b/src/main/java/net/imglib2/algorithm/math/OffsetRead.java
@@ -1,0 +1,51 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.math.abstractions.IFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
+import net.imglib2.algorithm.math.abstractions.ViewableFunction;
+import net.imglib2.algorithm.math.execution.OffsetReading;
+import net.imglib2.algorithm.math.execution.OffsetReadingDirect;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public final class OffsetRead< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
+{
+	final private RandomAccessible< I > src;
+	final private long[] offset;
+	
+	public OffsetRead( final RandomAccessible< I > src, final long[] offset )
+	{
+		this.src = src;
+		this.offset = offset;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		if ( tmp.getClass().isAssignableFrom( this.src.randomAccess().get().getClass() ) )
+			return new OffsetReadingDirect< O >(
+					tmp.copy(),
+					( RandomAccessible< O > )this.src,
+					this.offset );
+		return new OffsetReading< I, O >(
+				tmp.copy(),
+				converter,
+				this.src,
+				this.offset );
+	}
+	
+	public RandomAccessible< I > getRandomAccessible()
+	{
+		return this.src;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/OffsetSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/OffsetSource.java
@@ -1,0 +1,46 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.math.abstractions.IFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
+import net.imglib2.algorithm.math.abstractions.ViewableFunction;
+import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.RandomAccessibleOffsetSourceDirect;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class OffsetSource< I extends RealType< I > > extends ViewableFunction implements RandomAccessOnly< I >
+{
+	private final IFunction f;
+	private final long[] offset;
+	
+	public OffsetSource( final IFunction f, final long[] offset )
+	{
+		this.f = f;
+		this.offset = offset;
+	}
+	
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		return new RandomAccessibleOffsetSourceDirect< O >(
+				tmp.copy(),
+				new IterableRandomAccessibleFunction< O, O >( this.f, converter,  tmp.createVariable(), tmp.createVariable(), null ),
+				this.offset );
+	}
+
+	@Override
+	public RandomAccessible< I > getRandomAccessible()
+	{
+		return this.view();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/OrLogical.java
+++ b/src/main/java/net/imglib2/algorithm/math/OrLogical.java
@@ -1,0 +1,42 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.algorithm.math.abstractions.ABinaryFunction;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.LogicalOr;
+import net.imglib2.algorithm.math.execution.LogicalOrBoolean;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class OrLogical extends ABinaryFunction
+{	
+	public OrLogical( final Object c1, final Object c2 )
+	{
+		super( c1, c2 );
+	}
+	
+	public OrLogical( final Object... c )
+	{
+		super( c );
+	}
+	
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources );
+		final OFunction< O > b = this.b.reInit( tmp, bindings, converter, imgSources );
+	
+		
+		return a instanceof ABooleanFunction< ? > && b instanceof ABooleanFunction< ? > ?
+			new LogicalOrBoolean< O >( tmp.createVariable(), a, b )
+			: new LogicalOr< O >( tmp.createVariable(), a, b );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/Pow.java
+++ b/src/main/java/net/imglib2/algorithm/math/Pow.java
@@ -17,11 +17,6 @@ public final class Pow extends ABinaryFunction
 	{
 		super( o1, o2 );
 	}
-	
-	public Pow( final Object... obs )
-	{
-		super( obs );
-	}
 
 	@Override
 	public < O extends RealType< O > > OFunction< O > reInit(

--- a/src/main/java/net/imglib2/algorithm/math/Pow.java
+++ b/src/main/java/net/imglib2/algorithm/math/Pow.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import net.imglib2.algorithm.math.abstractions.ABinaryFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.NumericSource;
 import net.imglib2.algorithm.math.execution.Power;
 import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;
@@ -23,14 +24,20 @@ public final class Pow extends ABinaryFunction
 	}
 
 	@Override
-	public < O extends RealType< O > > Power< O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Power< O >( tmp.copy(),
-				this.a.reInit( tmp, bindings, converter, imgSources ),
-				this.b.reInit( tmp, bindings, converter, imgSources ) );
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources ),
+						     b = this.b.reInit( tmp, bindings, converter, imgSources );
+		
+		if ( b.isZero() )
+			return new NumericSource< O >( tmp.copy(), 1 );
+		if ( a.isOne() || b.isOne() )
+			return a;
+		
+		return new Power< O >( tmp.copy(), a, b );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/RandomAccessibleSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/RandomAccessibleSource.java
@@ -13,7 +13,7 @@ import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public final class RandomAccessibleSource< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
+public class RandomAccessibleSource< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly< I >
 {
 	final private RandomAccessible< I > src;
 	final private long[] offset;

--- a/src/main/java/net/imglib2/algorithm/math/RandomAccessibleSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/RandomAccessibleSource.java
@@ -6,19 +6,25 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
 import net.imglib2.algorithm.math.abstractions.ViewableFunction;
-import net.imglib2.algorithm.math.execution.OffsetReading;
-import net.imglib2.algorithm.math.execution.OffsetReadingDirect;
+import net.imglib2.algorithm.math.execution.RandomAccessibleOffsetSource;
+import net.imglib2.algorithm.math.execution.RandomAccessibleOffsetSourceDirect;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public final class OffsetRead< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
+public final class RandomAccessibleSource< I extends RealType< I > > extends ViewableFunction implements IFunction, RandomAccessOnly
 {
 	final private RandomAccessible< I > src;
 	final private long[] offset;
 	
-	public OffsetRead( final RandomAccessible< I > src, final long[] offset )
+	public RandomAccessibleSource( final RandomAccessible< I > src )
+	{
+		this.src = src;
+		this.offset = new long[ src.numDimensions() ]; // all zeros
+	}
+	
+	public RandomAccessibleSource( final RandomAccessible< I > src, final long[] offset )
 	{
 		this.src = src;
 		this.offset = offset;
@@ -33,11 +39,11 @@ public final class OffsetRead< I extends RealType< I > > extends ViewableFunctio
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
 		if ( tmp.getClass().isAssignableFrom( this.src.randomAccess().get().getClass() ) )
-			return new OffsetReadingDirect< O >(
+			return new RandomAccessibleOffsetSourceDirect< O >(
 					tmp.copy(),
 					( RandomAccessible< O > )this.src,
 					this.offset );
-		return new OffsetReading< I, O >(
+		return new RandomAccessibleOffsetSource< I, O >(
 				tmp.copy(),
 				converter,
 				this.src,

--- a/src/main/java/net/imglib2/algorithm/math/Sub.java
+++ b/src/main/java/net/imglib2/algorithm/math/Sub.java
@@ -7,6 +7,7 @@ import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Subtraction;
 import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.algorithm.math.execution.ZeroMinus;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
@@ -23,14 +24,21 @@ public final class Sub extends ABinaryFunction
 	}
 
 	@Override
-	public < O extends RealType< O > > Subtraction< O > reInit(
+	public < O extends RealType< O > > OFunction< O > reInit(
 			final O tmp,
 			final Map< String, LetBinding< O > > bindings,
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources )
 	{
-		return new Subtraction< O >( tmp.copy(),
-				this.a.reInit( tmp, bindings, converter, imgSources ),
-				this.b.reInit( tmp, bindings, converter, imgSources ) );
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources ),
+    			 			 b = this.b.reInit( tmp, bindings, converter, imgSources );
+
+		// Optimization: remove null ops
+		if ( b.isZero() )
+			return a;
+		if ( a.isZero() )
+			return new ZeroMinus< O >( tmp.copy(), b );
+		
+		return new Subtraction< O >( tmp.copy(), a, b );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Var.java
+++ b/src/main/java/net/imglib2/algorithm/math/Var.java
@@ -35,40 +35,4 @@ public final class Var implements IVar
 	{
 		return new Variable< O >( this.name, bindings.get( this.name ) );
 	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view()
-	{
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType )
-	{
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType, final Converter< RealType< ? >, O > converter )
-	{
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble()
-	{
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType )
-	{
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType, final Converter< RealType< ? >, O > converter )
-	{
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/Var.java
+++ b/src/main/java/net/imglib2/algorithm/math/Var.java
@@ -4,8 +4,6 @@ import java.util.Map;
 
 import net.imglib2.algorithm.math.abstractions.IVar;
 import net.imglib2.algorithm.math.abstractions.OFunction;
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunction;
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunctionDouble;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;

--- a/src/main/java/net/imglib2/algorithm/math/XorLogical.java
+++ b/src/main/java/net/imglib2/algorithm/math/XorLogical.java
@@ -1,0 +1,42 @@
+package net.imglib2.algorithm.math;
+
+import java.util.Map;
+
+import net.imglib2.algorithm.math.abstractions.ABinaryFunction;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.execution.LetBinding;
+import net.imglib2.algorithm.math.execution.LogicalXor;
+import net.imglib2.algorithm.math.execution.LogicalXorBoolean;
+import net.imglib2.algorithm.math.execution.Variable;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class XorLogical extends ABinaryFunction
+{	
+	public XorLogical( final Object c1, final Object c2 )
+	{
+		super( c1, c2 );
+	}
+	
+	public XorLogical( final Object... c )
+	{
+		super( c );
+	}
+	
+	@Override
+	public < O extends RealType< O > > OFunction< O > reInit(
+			final O tmp,
+			final Map< String, LetBinding< O > > bindings,
+			final Converter< RealType< ? >, O > converter,
+			final Map< Variable< O >, OFunction< O > > imgSources )
+	{
+		final OFunction< O > a = this.a.reInit( tmp, bindings, converter, imgSources );
+		final OFunction< O > b = this.b.reInit( tmp, bindings, converter, imgSources );
+	
+		
+		return a instanceof ABooleanFunction< ? > && b instanceof ABooleanFunction< ? > ?
+			new LogicalXorBoolean< O >( tmp.createVariable(), a, b )
+			: new LogicalXor< O >( tmp.createVariable(), a, b );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/ABooleanFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/ABooleanFunction.java
@@ -1,0 +1,16 @@
+package net.imglib2.algorithm.math.abstractions;
+
+import net.imglib2.type.numeric.RealType;
+
+public abstract class ABooleanFunction< O extends RealType< O > > implements IBooleanFunction, OFunction< O >
+{
+	protected final O zero, one;
+	
+	public ABooleanFunction( final O scrap )
+	{
+		this.zero = scrap.createVariable();
+		this.zero.setZero();
+		this.one = scrap.createVariable();
+		this.one.setOne();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/IFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/IFunction.java
@@ -17,16 +17,4 @@ public interface IFunction
 			final Converter< RealType< ? >, O > converter,
 			final Map< Variable< O >, OFunction< O > > imgSources
 			);
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view();
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType );
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType, final Converter< RealType< ? >, O > converter );
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble();
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType );
-	
-	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType, final Converter< RealType< ? >, O > converter );
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/IFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/IFunction.java
@@ -2,8 +2,6 @@ package net.imglib2.algorithm.math.abstractions;
 
 import java.util.Map;
 
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunction;
-import net.imglib2.algorithm.math.execution.IterableRandomAccessibleFunctionDouble;
 import net.imglib2.algorithm.math.execution.LetBinding;
 import net.imglib2.algorithm.math.execution.Variable;
 import net.imglib2.converter.Converter;

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/IImgSourceIterable.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/IImgSourceIterable.java
@@ -1,12 +1,8 @@
 package net.imglib2.algorithm.math.abstractions;
 
-import net.imglib2.Localizable;
+import net.imglib2.Cursor;
 
-public interface IImgSourceIterable
-{
-	public boolean hasNext();
-	
-	public Localizable localizable();
-	
-	public void localize( final long[] position );
+public interface IImgSourceIterable< I >
+{	
+	public Cursor< I > getCursor();
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/OFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/OFunction.java
@@ -16,4 +16,15 @@ public interface OFunction< O extends RealType< O > >
 	public double evalDouble();
 	
 	public double evalDouble( final Localizable loc );
+	
+
+	default public boolean isOne()
+	{
+		return false;
+	}
+
+	default public boolean isZero()
+	{
+		return false;
+	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
@@ -1,9 +1,13 @@
 package net.imglib2.algorithm.math.abstractions;
 
-public interface RandomAccessOnly
+import net.imglib2.RandomAccessible;
+
+public interface RandomAccessOnly< I >
 {
 	public default boolean isRandomAccessOnly()
 	{
 		return true;
 	}
+	
+	public RandomAccessible< I > getRandomAccessible();
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
@@ -1,3 +1,9 @@
 package net.imglib2.algorithm.math.abstractions;
 
-public interface RandomAccessOnly {}
+public interface RandomAccessOnly
+{
+	public default boolean isRandomAccessOnly()
+	{
+		return true;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/RandomAccessOnly.java
@@ -1,0 +1,3 @@
+package net.imglib2.algorithm.math.abstractions;
+
+public interface RandomAccessOnly {}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/SourceInterval.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/SourceInterval.java
@@ -1,0 +1,8 @@
+package net.imglib2.algorithm.math.abstractions;
+
+import net.imglib2.Interval;
+
+public interface SourceInterval
+{
+	public Interval getInterval();
+}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
@@ -289,7 +289,7 @@ public class Util
 		};
 	}
 
-	public static final < O extends RealType< O > > IImgSourceIterable findFirstIterableImgSource( final OFunction< O > f )
+	public static final < O extends RealType< O > > IImgSourceIterable< ? > findFirstIterableImgSource( final OFunction< O > f )
 	{
 		final LinkedList< OFunction< O > > ops = new LinkedList<>();
 		ops.addLast( f );
@@ -300,8 +300,8 @@ public class Util
 			final OFunction< O >  op = ops.removeFirst();
 			for ( final OFunction< O > cf : op.children() )
 			{
-				if ( cf instanceof IImgSourceIterable )
-					return ( IImgSourceIterable ) cf;
+				if ( cf instanceof IImgSourceIterable< ? > )
+					return ( IImgSourceIterable< ? > ) cf;
 				ops.addLast( cf );
 			}
 		}
@@ -309,12 +309,12 @@ public class Util
 		return null;
 	}
 	
-	public static final < O extends RealType< O > > List< IImgSourceIterable > findAllIterableImgSource( final OFunction< O > f )
+	public static final < O extends RealType< O > > List< IImgSourceIterable< ? > > findAllIterableImgSource( final OFunction< O > f )
 	{
 		final LinkedList< OFunction< O > > ops = new LinkedList<>();
 		ops.addLast( f );
 		
-		final List< IImgSourceIterable > iis = new ArrayList<>();
+		final List< IImgSourceIterable< ? > > iis = new ArrayList<>();
 		
 		// Iterate into the nested operations
 		while ( ! ops.isEmpty() )
@@ -322,8 +322,8 @@ public class Util
 			final OFunction< O >  op = ops.removeFirst();
 			for ( final OFunction< O > cf : op.children() )
 			{
-				if ( cf instanceof IImgSourceIterable )
-					iis.add( ( IImgSourceIterable ) cf );
+				if ( cf instanceof IImgSourceIterable< ? > )
+					iis.add( ( IImgSourceIterable< ? > ) cf );
 				else
 					ops.addLast( cf );
 			}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
@@ -296,7 +296,7 @@ public class Util
 		// Iterate into the nested operations, depth-first
 		while ( ! ops.isEmpty() )
 		{
-			final IFunction  op = ops.removeFirst();
+			final IFunction op = ops.removeFirst();
 
 			String indent = indents.removeFirst();
 			String pre = "";
@@ -332,6 +332,34 @@ public class Util
 			hierarchy.append( indent + pre + op.getClass().getSimpleName() + post + "\n");
 		}
 
+		return hierarchy.toString();
+	}
+	
+	public static final String hierarchy( final OFunction< ? > f )
+	{	
+		final StringBuilder hierarchy = new StringBuilder();
+		final LinkedList< String > indents = new LinkedList<>();
+		indents.add("");
+		
+		final LinkedList< OFunction< ? > > ops = new LinkedList<>();
+		ops.addLast( f );
+		
+		// Iterate into the nested operations
+		while ( ! ops.isEmpty() )
+		{
+			final OFunction< ? >  op = ops.removeFirst();
+			
+			final String indent = indents.removeFirst();
+			
+			for ( final OFunction< ? > cf : op.children() )
+			{
+				ops.addFirst( cf );
+				indents.addFirst( indent + "  " );
+			}
+			
+			hierarchy.append( indent + op.getClass().getSimpleName() + "\n");
+		}
+		
 		return hierarchy.toString();
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
@@ -8,10 +8,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.math.ImgSource;
 import net.imglib2.algorithm.math.Let;
 import net.imglib2.algorithm.math.NumberSource;
+import net.imglib2.algorithm.math.RandomAccessibleSource;
 import net.imglib2.algorithm.math.Var;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.IntegerType;
@@ -72,19 +75,23 @@ public class Util
 	{
 		if ( o instanceof RandomAccessibleInterval< ? > )
 		{
-			return new ImgSource( (RandomAccessibleInterval) o );
+			return new ImgSource( ( RandomAccessibleInterval )o );
+		}
+		else if ( o instanceof RandomAccessible< ? > )
+		{
+			return new RandomAccessibleSource( ( RandomAccessible )o );
 		}
 		else if ( o instanceof Number )
 		{
-			return new NumberSource( ( (Number) o ).doubleValue() );
+			return new NumberSource( ( ( Number )o ).doubleValue() );
 		}
 		else if ( o instanceof IFunction )
 		{
-			return ( (IFunction) o );
+			return ( ( IFunction ) o );
 		}
 		else if ( o instanceof String )
 		{
-			return new Var( (String)o );
+			return new Var( ( String )o );
 		}
 		
 		// Make it fail
@@ -135,6 +142,37 @@ public class Util
 			
 			if ( op instanceof ImgSource )
 				return ( ( ImgSource< ? > )op ).getRandomAccessibleInterval();
+			else if ( op instanceof IUnaryFunction )
+			{
+				ops.addLast( ( ( IUnaryFunction )op ).getFirst() );
+				
+				if ( op instanceof IBinaryFunction )
+				{
+					ops.addLast( ( ( IBinaryFunction )op ).getSecond() );
+					
+					if ( op instanceof ITrinaryFunction )
+					{
+						ops.addLast( ( ( ITrinaryFunction )op ).getThird() );
+					}
+				}
+			}
+		}
+		
+		return null;
+	}
+	
+	static public final Interval findFirstInterval ( final IFunction f )
+	{
+		final LinkedList< IFunction > ops = new LinkedList<>();
+		ops.add( f );
+		
+		// Iterate into the nested operations
+		while ( ! ops.isEmpty() )
+		{
+			final IFunction  op = ops.removeFirst();
+			
+			if ( op instanceof SourceInterval )
+				return ( ( SourceInterval )op ).getInterval();
 			else if ( op instanceof IUnaryFunction )
 			{
 				ops.addLast( ( ( IUnaryFunction )op ).getFirst() );

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/Util.java
@@ -14,6 +14,7 @@ import net.imglib2.algorithm.math.Let;
 import net.imglib2.algorithm.math.NumberSource;
 import net.imglib2.algorithm.math.Var;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
@@ -184,6 +185,18 @@ public class Util
 			public final void convert( final RealType< ? > input, final O output)
 			{
 				output.setReal( input.getRealDouble() );
+			}
+		};
+	}
+	
+	static public final< I extends IntegerType< I >, O extends IntegerType< O > > Converter< I, O > genericIntegerTypeConverter()
+	{
+		return new Converter< I, O >()
+		{
+			@Override
+			public final void convert( final I input, O output )
+			{
+				output.setInteger( input.getIntegerLong() );
 			}
 		};
 	}

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/ViewableFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/ViewableFunction.java
@@ -7,19 +7,24 @@ import net.imglib2.type.numeric.RealType;
 
 public abstract class ViewableFunction implements IFunction
 {
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view()
+	public < C extends RealType< C >, O extends RealType< O > > IterableRandomAccessibleFunction< C, O > view()
 	{
-		return new IterableRandomAccessibleFunction< O >( this );
+		return new IterableRandomAccessibleFunction< C, O >( this );
 	}
 	
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType )
+	public < C extends RealType< C >, O extends RealType< O > > IterableRandomAccessibleFunction< C, O > view( final O outputType )
 	{
-		return new IterableRandomAccessibleFunction< O >( this, outputType );
+		return new IterableRandomAccessibleFunction< C, O >( this, outputType );
 	}
 	
-	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType, final Converter< RealType< ? >, O > converter )
+	public < C extends RealType< C >, O extends RealType< O > > IterableRandomAccessibleFunction< C, O > view( final C computeType, final O outputType )
 	{
-		return new IterableRandomAccessibleFunction< O >( this, outputType, converter );
+		return new IterableRandomAccessibleFunction< C, O >( this, null, computeType, outputType, null );
+	}
+	
+	public < C extends RealType< C >, O extends RealType< O > > IterableRandomAccessibleFunction< C, O > view( final O outputType, final Converter< C, O > converter )
+	{
+		return new IterableRandomAccessibleFunction< C, O >( this, outputType, converter );
 	}
 	
 	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble()

--- a/src/main/java/net/imglib2/algorithm/math/abstractions/ViewableFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/abstractions/ViewableFunction.java
@@ -7,37 +7,31 @@ import net.imglib2.type.numeric.RealType;
 
 public abstract class ViewableFunction implements IFunction
 {
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view()
 	{
 		return new IterableRandomAccessibleFunction< O >( this );
 	}
 	
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType )
 	{
 		return new IterableRandomAccessibleFunction< O >( this, outputType );
 	}
 	
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunction< O > view( final O outputType, final Converter< RealType< ? >, O > converter )
 	{
 		return new IterableRandomAccessibleFunction< O >( this, outputType, converter );
 	}
 	
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble()
 	{
 		return new IterableRandomAccessibleFunctionDouble< O >( this );
 	}
 	
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType )
 	{
 		return new IterableRandomAccessibleFunctionDouble< O >( this, outputType );
 	}
 	
-	@Override
 	public < O extends RealType< O > > IterableRandomAccessibleFunctionDouble< O > viewDouble( final O outputType, final Converter< RealType< ? >, O > converter )
 	{
 		return new IterableRandomAccessibleFunctionDouble< O >( this, outputType, converter );

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
@@ -41,9 +41,9 @@ public class BlockReading< I extends RealType< I >, O extends RealType< O > > im
 				this.moves[ i ][ j ] = corners[ i ][ j ] - corners[ i - 1 ][ j ];
 		this.signs = signs;
 		
-		for (int i=0; i<this.moves.length; ++i)
-			for (int j=0; j<this.moves[0].length; ++j)
-				System.out.println( "moves[" + i + "][" + j + "] = " + this.moves[i][j]);
+		//for (int i=0; i<this.moves.length; ++i)
+		//	for (int j=0; j<this.moves[0].length; ++j)
+		//		System.out.println( "moves[" + i + "][" + j + "] = " + this.moves[i][j]);
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
@@ -1,0 +1,103 @@
+package net.imglib2.algorithm.math.execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+
+public class BlockReading< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
+{
+	private final RandomAccessible< I > src;
+	protected final RandomAccess< I > ra;
+	protected final O scrap, tmp;
+	private final Converter< RealType< ? >, O > converter;
+	/** First move is relative to the location, rest of moves are relative to prior move. */
+	protected final long[][] moves;
+	protected final byte[] signs;
+	
+	public BlockReading(
+			final O scrap,
+			final Converter< RealType< ? >, O > converter,
+			final RandomAccessible< I > src,
+			final long[][] corners,
+			final byte[] signs
+			)
+	{
+		this.scrap = scrap;
+		this.tmp = scrap.createVariable();
+		this.src = src;
+		this.converter = converter;
+		this.ra = src.randomAccess();
+		this.moves = new long[ corners.length ][ corners[ 0 ].length ];
+		this.moves[ 0 ] = corners[ 0 ]; // corners are relative
+		for ( int i = 1; i < corners.length; ++i )
+			for ( int j = 0; j < corners[ 0 ].length; ++ j )
+				this.moves[ i ][ 0 ] = corners[ i ][ j ] - corners[ i - 1 ][ j ];
+		this.signs = signs;
+	}
+	
+	@Override
+	public final O eval()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public O eval( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		this.ra.move( this.moves[ 0 ] );
+		this.converter.convert( this.ra.get(), this.scrap );
+		this.scrap.mul( this.signs[ 0 ] );
+		for ( int i = 1; i < this.moves.length; ++i )
+		{
+			this.ra.move( this.moves[ i ] );
+			this.converter.convert( this.ra.get(), this.tmp );
+			// this.tmp.mul( this.signs[ i ] );
+			// this.scrap.add( tmp );
+			// Less method calls: theoretically faster, but branching
+			if ( 1 == this.signs[ i ] )
+				this.scrap.add( tmp );
+			else
+				this.scrap.sub( tmp );
+		}
+		return this.scrap;
+	}
+	
+	@Override
+	public List< OFunction< O > > children()
+	{
+		return Arrays.asList();
+	}
+	
+	@Override
+	public final double evalDouble()
+	{
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public final double evalDouble( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		this.ra.move( this.moves[ 0 ] );
+		double sum = this.ra.get().getRealDouble() * this.signs[ 0 ];
+		for ( int i = 1; i < this.moves.length; ++i )
+		{
+			this.ra.move( this.moves[ i ] );
+			sum += this.ra.get().getRealDouble() * this.signs[ i ];
+		}
+		return sum;
+	}
+	
+	public RandomAccessible< I > getRandomAccessible()
+	{
+		return this.src;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
@@ -90,9 +90,8 @@ public class BlockReading< I extends RealType< I >, O extends RealType< O > > im
 	public final double evalDouble( final Localizable loc )
 	{
 		this.ra.setPosition( loc );
-		this.ra.move( this.moves[ 0 ] );
-		double sum = this.ra.get().getRealDouble() * this.signs[ 0 ];
-		for ( int i = 1; i < this.moves.length; ++i )
+		double sum = 0;
+		for ( int i = 0; i < this.moves.length; ++i )
 		{
 			this.ra.move( this.moves[ i ] );
 			sum += this.ra.get().getRealDouble() * this.signs[ i ];

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReading.java
@@ -35,11 +35,15 @@ public class BlockReading< I extends RealType< I >, O extends RealType< O > > im
 		this.converter = converter;
 		this.ra = src.randomAccess();
 		this.moves = new long[ corners.length ][ corners[ 0 ].length ];
-		this.moves[ 0 ] = corners[ 0 ]; // corners are relative
+		this.moves[ 0 ] = corners[ 0 ]; // corners are relative to a pixel position
 		for ( int i = 1; i < corners.length; ++i )
-			for ( int j = 0; j < corners[ 0 ].length; ++ j )
-				this.moves[ i ][ 0 ] = corners[ i ][ j ] - corners[ i - 1 ][ j ];
+			for ( int j = 0; j < corners[ 0 ].length; ++j )
+				this.moves[ i ][ j ] = corners[ i ][ j ] - corners[ i - 1 ][ j ];
 		this.signs = signs;
+		
+		for (int i=0; i<this.moves.length; ++i)
+			for (int j=0; j<this.moves[0].length; ++j)
+				System.out.println( "moves[" + i + "][" + j + "] = " + this.moves[i][j]);
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
@@ -21,10 +21,12 @@ public class BlockReadingDirect< O extends RealType< O > > extends BlockReading<
 	{
 		this.ra.setPosition( loc );
 		this.ra.move( this.moves[ 0 ] );
+		this.scrap.set( this.ra.get() );
 		this.scrap.mul( this.signs[ 0 ] );
 		for ( int i = 1; i < this.moves.length; ++i )
 		{
 			this.ra.move( this.moves[ i ] );
+			this.tmp.set( this.ra.get() );
 			// this.tmp.mul( this.signs[ i ] );
 			// this.scrap.add( tmp );
 			// Less method calls: theoretically faster, but branching

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
@@ -1,0 +1,38 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccessible;
+import net.imglib2.type.numeric.RealType;
+
+public class BlockReadingDirect< O extends RealType< O > > extends BlockReading< O, O >
+{
+	public BlockReadingDirect(
+			final O scrap,
+			final RandomAccessible< O > src,
+			final long[][] corners,
+			final byte[] signs
+			)
+	{
+		super( scrap, null, src, corners, signs );
+	}
+	
+	@Override
+	public O eval( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		this.ra.move( this.moves[ 0 ] );
+		this.scrap.mul( this.signs[ 0 ] );
+		for ( int i = 1; i < this.moves.length; ++i )
+		{
+			this.ra.move( this.moves[ i ] );
+			// this.tmp.mul( this.signs[ i ] );
+			// this.scrap.add( tmp );
+			// Less method calls: theoretically faster, but branching
+			if ( 1 == this.signs[ i ] )
+				this.scrap.add( tmp );
+			else
+				this.scrap.sub( tmp );
+		}
+		return this.scrap;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingDirect.java
@@ -4,7 +4,7 @@ import net.imglib2.Localizable;
 import net.imglib2.RandomAccessible;
 import net.imglib2.type.numeric.RealType;
 
-public class BlockReadingDirect< O extends RealType< O > > extends BlockReading< O, O >
+public class BlockReadingDirect< O extends RealType< O > > extends BlockReadingSource< O, O >
 {
 	public BlockReadingDirect(
 			final O scrap,

--- a/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/BlockReadingSource.java
@@ -11,7 +11,7 @@ import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class BlockReading< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
+public class BlockReadingSource< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly< I >
 {
 	private final RandomAccessible< I > src;
 	protected final RandomAccess< I > ra;
@@ -21,7 +21,7 @@ public class BlockReading< I extends RealType< I >, O extends RealType< O > > im
 	protected final long[][] moves;
 	protected final byte[] signs;
 	
-	public BlockReading(
+	public BlockReadingSource(
 			final O scrap,
 			final Converter< RealType< ? >, O > converter,
 			final RandomAccessible< I > src,

--- a/src/main/java/net/imglib2/algorithm/math/execution/Comparison.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/Comparison.java
@@ -4,22 +4,19 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.imglib2.Localizable;
-import net.imglib2.algorithm.math.abstractions.IBooleanFunction;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.type.numeric.RealType;
 
-abstract public class Comparison< O extends RealType< O > > implements OFunction< O >, IBooleanFunction
+abstract public class Comparison< O extends RealType< O > > extends ABooleanFunction< O >
 {
-	private final OFunction< O > a, b;
-	private final O zero, one;
-	
-	public Comparison( final O scrap, final OFunction< O > a, final OFunction< O > b) {
+	protected final OFunction< O > a, b;
+
+	public Comparison( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap );
 		this.a = a;
 		this.b = b;
-		this.zero = scrap.createVariable();
-		this.zero.setZero();
-		this.one = scrap.createVariable();
-		this.one.setOne();
 	}
 	
 	abstract protected boolean compare( final O t1, final O t2 );
@@ -37,19 +34,19 @@ abstract public class Comparison< O extends RealType< O > > implements OFunction
 	}
 	
 	@Override
-	public final boolean evalBoolean()
+	public boolean evalBoolean()
 	{
 		return this.compare( this.a.eval(), this.b.eval() );
 	}
 	
 	@Override
-	public final boolean evalBoolean( final Localizable loc )
+	public boolean evalBoolean( final Localizable loc )
 	{
 		return this.compare( this.a.eval( loc ), this.b.eval( loc ) );
 	}
 	
 	@Override
-	public List< OFunction< O > > children()
+	public final List< OFunction< O > > children()
 	{
 		return Arrays.asList( this.a, this.b );
 	}

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorDouble.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorDouble.java
@@ -5,22 +5,22 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class FunctionCursorDouble< O extends RealType< O > > extends FunctionCursor< O >
+public class FunctionCursorDouble< O extends RealType< O > > extends FunctionCursor< O, O >
 {
 	public FunctionCursorDouble( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( operation, outputType, converter );
+		super( operation, null, outputType.createVariable(), outputType, ( Converter< O, O > )converter );
 	}
 
 	@Override
 	public void fwd()
 	{
-		this.scrap.setReal( this.f.evalDouble() );
+		this.scrapC.setReal( this.f.evalDouble() );
 	}
 	
 	@Override
 	public AbstractCursor< O > copy()
 	{
-		return new FunctionCursorDouble< O >( this.operation, this.outputType, this.converter );
+		return new FunctionCursorDouble< O >( this.operation, this.scrapO.createVariable(), ( Converter< RealType< ? >, O> )this.outConverter );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorDoubleIncompatibleOrder.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorDoubleIncompatibleOrder.java
@@ -6,22 +6,22 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class FunctionCursorDoubleIncompatibleOrder< O extends RealType< O > > extends FunctionCursor< O > implements Cursor< O >
+public class FunctionCursorDoubleIncompatibleOrder< O extends RealType< O > > extends FunctionCursor< O, O > implements Cursor< O >
 {
 	public FunctionCursorDoubleIncompatibleOrder( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( operation, outputType, converter );
+		super( operation, null, outputType.createVariable(), outputType, ( Converter< O, O > )converter );
 	}
 
 	@Override
 	public void fwd()
 	{
-		this.scrap.setReal( this.f.evalDouble( this.ii.localizable() ) );
+		this.scrapC.setReal( this.f.evalDouble( this.cursor ) );
 	}
 	
 	@Override
 	public AbstractCursor< O > copy()
 	{
-		return new FunctionCursorDoubleIncompatibleOrder< O >( this.operation, this.outputType, this.converter );
+		return new FunctionCursorDoubleIncompatibleOrder< O >( this.operation, this.scrapO, ( Converter< RealType< ? >, O > )this.outConverter );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorIncompatibleOrder.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionCursorIncompatibleOrder.java
@@ -6,22 +6,27 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class FunctionCursorIncompatibleOrder< O extends RealType< O > > extends FunctionCursor< O > implements Cursor< O >
+public class FunctionCursorIncompatibleOrder< C extends RealType< C >, O extends RealType< O > > extends FunctionCursor< C, O > implements Cursor< O >
 {
-	public FunctionCursorIncompatibleOrder( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
+	public FunctionCursorIncompatibleOrder(
+			final IFunction operation,
+			final Converter< RealType< ? >, C > inConverter,
+			final C computeType,
+			final O outputType,
+			final Converter< C, O > outConverter )
 	{
-		super( operation, outputType, converter );
+		super( operation, inConverter, computeType, outputType, outConverter );
 	}
 
 	@Override
 	public void fwd()
 	{
-		this.scrap = this.f.eval( this.ii.localizable() ); 
+		this.scrapC = this.f.eval( this.cursor );
 	}
 	
 	@Override
 	public AbstractCursor< O > copy()
 	{
-		return new FunctionCursorIncompatibleOrder< O >( this.operation, this.outputType, this.converter );
+		return new FunctionCursorIncompatibleOrder< C, O >( this.operation, this.inConverter, this.scrapC, this.scrapO, this.outConverter );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccess.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccess.java
@@ -17,7 +17,7 @@ public class FunctionRandomAccess< O extends RealType< O > > extends Point imple
 
 	public FunctionRandomAccess( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( Util.findFirstImg( operation ).numDimensions() );
+		super( Util.findFirstInterval( operation ).numDimensions() );
 		this.sampler = new FunctionSampler( this, operation, outputType, converter );
 	}
 	

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccess.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccess.java
@@ -9,43 +9,128 @@ import net.imglib2.algorithm.math.abstractions.IFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.algorithm.math.abstractions.Util;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 
-public class FunctionRandomAccess< O extends RealType< O > > extends Point implements RandomAccess< O >
+public class FunctionRandomAccess< C extends RealType< C >, O extends RealType< O > > extends Point implements RandomAccess< O >
 {
-	private final FunctionSampler sampler;
+	private final IFunction operation;
+	private final C computeType;
+	private final O outputType;
+	private final Converter< RealType< ? >, C > inConverter;
+	private final Converter< C, O > outConverter;
+	private final Sampler< O > sampler;
 
-	public FunctionRandomAccess( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
+	@SuppressWarnings("unchecked")
+	public FunctionRandomAccess(
+			final IFunction operation,
+			Converter< RealType< ? >, C > inConverter,
+			final C computeType,
+			final O outputType,
+			Converter< C, O > outConverter )
 	{
 		super( Util.findFirstInterval( operation ).numDimensions() );
-		this.sampler = new FunctionSampler( this, operation, outputType, converter );
+		if ( null == inConverter )
+			inConverter = Util.genericRealTypeConverter();
+		
+		final boolean are_same_type = computeType.getClass() == outputType.getClass();
+		
+		if ( null == outConverter && !are_same_type )
+		{
+			if ( computeType instanceof IntegerType && outputType instanceof IntegerType )
+				outConverter = ( Converter< C, O > )Util.genericIntegerTypeConverter();
+			else
+				outConverter = ( Converter< C, O > )Util.genericRealTypeConverter();
+		}
+		
+		if ( are_same_type )
+			this.sampler = new FunctionSamplerDirect( this, operation, ( Converter< RealType< ? >, O > )inConverter, outputType );
+		else
+			this.sampler = new FunctionSampler( this, operation, inConverter, computeType, outputType, outConverter );
+		
+		this.operation = operation;
+		this.inConverter = inConverter;
+		this.outConverter = outConverter;
+		this.computeType = computeType;
+		this.outputType = outputType;
 	}
 	
 	private final class FunctionSampler implements Sampler< O >
 	{
 		private final Point point;
 		private final IFunction operation;
+		private final C computeType;
 		private final O outputType;
-		private final Converter< RealType< ? >, O > converter;
-		private final OFunction< O > f;
+		private final Converter< RealType< ? >, C > inConverter;
+		private final Converter< C, O > outConverter;
+		private final OFunction< C > f;
 		
-		FunctionSampler( final Point point, final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
+		FunctionSampler(
+				final Point point,
+				final IFunction operation,
+				final Converter< RealType< ? >, C > inConverter,
+				final C computeType,
+				final O outputType,
+				final Converter< C, O > outConverter
+				)
 		{
 			this.point = point;
 			this.operation = operation;
+			this.computeType = computeType;
 			this.outputType = outputType.createVariable();
-			this.converter = converter;
+			this.inConverter = inConverter;
+			this.outConverter = outConverter;
 			this.f = operation.reInit(
-					outputType.copy(),
-					new HashMap< String, LetBinding< O > >(),
-					null == converter ? Util.genericRealTypeConverter() : converter,
+					computeType.createVariable(),
+					new HashMap< String, LetBinding< C > >(),
+					inConverter,
 					null );
 		}
 		
 		@Override
 		public final Sampler< O > copy()
 		{
-			return new FunctionSampler( this.point, this.operation, this.outputType, this.converter );
+			return new FunctionSampler( this.point, this.operation, this.inConverter, this.computeType, this.outputType, this.outConverter );
+		}
+
+		@Override
+		public O get()
+		{
+			this.outConverter.convert( this.f.eval( this.point ), outputType );
+			return this.outputType;
+		}
+	}
+	
+	private final class FunctionSamplerDirect implements Sampler< O >
+	{
+		private final Point point;
+		private final IFunction operation;
+		private final O outputType;
+		private final Converter< RealType< ? >, O > inConverter;
+		private final OFunction< O > f;
+		
+		FunctionSamplerDirect(
+				final Point point,
+				final IFunction operation,
+				final Converter< RealType< ? >, O > inConverter,
+				final O outputType
+				)
+		{
+			this.point = point;
+			this.operation = operation;
+			this.outputType = outputType.createVariable();
+			this.inConverter = inConverter;
+			this.f = operation.reInit(
+					outputType.createVariable(),
+					new HashMap< String, LetBinding< O > >(),
+					inConverter,
+					null );
+		}
+		
+		@Override
+		public final Sampler< O > copy()
+		{
+			return new FunctionSamplerDirect( this.point, this.operation, this.inConverter, this.outputType );
 		}
 
 		@Override
@@ -70,6 +155,11 @@ public class FunctionRandomAccess< O extends RealType< O > > extends Point imple
 	@Override
 	public RandomAccess< O > copyRandomAccess()
 	{
-		return new FunctionRandomAccess< O >( this.sampler.operation, this.sampler.outputType, this.sampler.converter );
+		return new FunctionRandomAccess< C, O >(
+				this.operation,
+				this.inConverter,
+				this.computeType,
+				this.outputType,
+				this.outConverter );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccessDouble.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/FunctionRandomAccessDouble.java
@@ -17,7 +17,7 @@ public class FunctionRandomAccessDouble< O extends RealType< O > > extends Point
 
 	public FunctionRandomAccessDouble( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( Util.findFirstImg( operation ).numDimensions() );
+		super( Util.findFirstInterval( operation ).numDimensions() );
 		this.sampler = new FunctionSampler( this, operation, outputType, converter );
 	}
 	

--- a/src/main/java/net/imglib2/algorithm/math/execution/IfStatement.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/IfStatement.java
@@ -31,11 +31,11 @@ public class IfStatement< O extends RealType< O > > implements OFunction< O >
 	@Override
 	public final O eval( final Localizable loc )
 	{
-		return 0 != this.a.eval().getRealFloat() ?
+		return 0 != this.a.eval( loc ).getRealFloat() ?
 			// Then
-			this.b.eval()
+			this.b.eval( loc )
 			// Else
-			: this.c.eval();
+			: this.c.eval( loc );
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/IfStatementBoolean.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/IfStatementBoolean.java
@@ -4,15 +4,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
 import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.type.numeric.RealType;
 
 public class IfStatementBoolean< O extends RealType< O > > implements OFunction< O >
 {
-	private final Comparison< O > abool;
+	private final ABooleanFunction< O > abool;
 	private final OFunction< O > b, c;
 	
-	public IfStatementBoolean( final Comparison< O > f1, final OFunction< O > f2, final OFunction< O > f3 )
+	public IfStatementBoolean( final ABooleanFunction< O > f1, final OFunction< O > f2, final OFunction< O > f3 )
 	{
 		this.abool = f1;
 		this.b = f2;

--- a/src/main/java/net/imglib2/algorithm/math/execution/ImgSourceIterable.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/ImgSourceIterable.java
@@ -13,7 +13,7 @@ import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
-public class ImgSourceIterable< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, IImgSourceIterable
+public class ImgSourceIterable< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, IImgSourceIterable< I >
 {
 	private final RandomAccessibleInterval< I > rai;
 	private final Cursor< I > it;
@@ -51,21 +51,9 @@ public class ImgSourceIterable< I extends RealType< I >, O extends RealType< O >
 	}
 
 	@Override
-	public boolean hasNext()
-	{
-		return this.it.hasNext();
-	}
-
-	@Override
-	public Localizable localizable()
+	public Cursor< I > getCursor()
 	{
 		return this.it;
-	}
-
-	@Override
-	public void localize(long[] position)
-	{
-		this.it.localize( position );
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/ImgSourceIterableDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/ImgSourceIterableDirect.java
@@ -12,7 +12,7 @@ import net.imglib2.algorithm.math.abstractions.OFunction;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
-public class ImgSourceIterableDirect< O extends RealType< O > > implements OFunction< O >, IImgSourceIterable
+public class ImgSourceIterableDirect< O extends RealType< O > > implements OFunction< O >, IImgSourceIterable< O >
 {
 	private final RandomAccessibleInterval< O > rai;
 	private final Cursor< O > it;
@@ -44,21 +44,9 @@ public class ImgSourceIterableDirect< O extends RealType< O > > implements OFunc
 	}
 
 	@Override
-	public boolean hasNext()
-	{
-		return this.it.hasNext();
-	}
-
-	@Override
-	public Localizable localizable()
+	public Cursor< O > getCursor()
 	{
 		return this.it;
-	}
-
-	@Override
-	public void localize( final long[] position)
-	{
-		this.it.localize( position );
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/IterableRandomAccessibleFunction.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/IterableRandomAccessibleFunction.java
@@ -40,7 +40,7 @@ implements RandomAccessibleInterval< O >, IterableInterval< O >, View
 
 	public IterableRandomAccessibleFunction( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( Util.findFirstImg( operation ) );
+		super( Util.findFirstInterval( operation ) );
 		this.operation = operation;
 		this.firstImg = Util.findFirstImg( operation ); // Twice: unavoidable
 		this.outputType = outputType;
@@ -62,7 +62,7 @@ implements RandomAccessibleInterval< O >, IterableInterval< O >, View
 	@SuppressWarnings("unchecked")
 	public IterableRandomAccessibleFunction( final IFunction operation )
 	{
-		super( Util.findFirstImg( operation ) );
+		super( Util.findFirstInterval( operation ) );
 		this.operation = operation;
 		this.firstImg = Util.findFirstImg( operation ); // Twice: unavoidable
 		this.outputType = ( ( O ) this.firstImg.randomAccess().get() ).createVariable();

--- a/src/main/java/net/imglib2/algorithm/math/execution/IterableRandomAccessibleFunctionDouble.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/IterableRandomAccessibleFunctionDouble.java
@@ -8,11 +8,11 @@ import net.imglib2.algorithm.math.abstractions.Util;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 
-public class IterableRandomAccessibleFunctionDouble< O extends RealType< O >> extends IterableRandomAccessibleFunction< O >
+public class IterableRandomAccessibleFunctionDouble< O extends RealType< O >> extends IterableRandomAccessibleFunction< O, O >
 {
 	public IterableRandomAccessibleFunctionDouble( final IFunction operation, final O outputType, final Converter< RealType< ? >, O > converter )
 	{
-		super( operation, outputType, converter );
+		super( operation, null, outputType.createVariable(), outputType, ( Converter< O, O > )converter );
 	}
 	
 	/**
@@ -31,12 +31,12 @@ public class IterableRandomAccessibleFunctionDouble< O extends RealType< O >> ex
 	@Override
 	public RandomAccess< O > randomAccess()
 	{
-		return new Compute( this.operation ).randomAccessDouble( this.outputType, this.converter );
+		return new Compute( this.operation ).randomAccessDouble( this.outputType, ( Converter< RealType< ? >, O > )this.outConverter );
 	}
 
 	@Override
 	public Cursor< O > cursor()
 	{
-		return new Compute( this.operation ).cursorDouble( this.outputType, this.converter );
+		return new Compute( this.operation ).cursorDouble( this.outputType, ( Converter< RealType< ? >, O > )this.outConverter );
 	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/KDTreeRadiusSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/KDTreeRadiusSource.java
@@ -1,0 +1,127 @@
+package net.imglib2.algorithm.math.execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.KDTree;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.Sampler;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.converter.Converter;
+import net.imglib2.neighborsearch.NearestNeighborSearchOnKDTree;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+public class KDTreeRadiusSource< I extends RealType< I >, O extends RealType< O > >
+extends Point
+implements OFunction< O >, RandomAccess< O >, RandomAccessible< O >
+{
+	private final KDTree< I > kdtree;
+	private final NearestNeighborSearchOnKDTree< I > search;
+	private final Cursor< O > cursor;
+	private final O scrap;
+	private final double radius, radius_squared;
+	private final I outside;
+	private final O outsideO;
+	private final Converter< RealType< ? >, O > converter;
+	private final Interval interval;
+	
+	public KDTreeRadiusSource(
+			final O scrap,
+			final Converter< RealType< ? >, O > converter,
+			final KDTree< I > kdtree,
+			final double radius,
+			final I outside,
+			final Interval interval
+			)
+	{
+		super( kdtree.numDimensions() );
+		this.scrap = scrap;
+		this.converter = converter;
+		this.kdtree = kdtree;
+		this.radius = radius;
+		this.radius_squared = radius * radius;
+		this.outside = outside;
+		this.search = new NearestNeighborSearchOnKDTree< I >( kdtree );
+		this.outsideO = scrap.createVariable();
+		converter.convert( outside, this.outsideO );
+		this.interval = interval;
+		this.cursor = Views.zeroMin( Views.interval( this, interval ) ).cursor();
+	}
+	
+	// Methods from interface RandomAccess
+	@Override
+	public O get()
+	{
+		this.search.search( this );
+		if ( this.search.getSquareDistance() < this.radius_squared )
+		{
+			this.converter.convert( this.search.getSampler().get(), this.scrap );
+			return this.scrap;
+		}
+		return this.outsideO;
+	}
+
+	@Override
+	public Sampler< O > copy()
+	{
+		return new KDTreeRadiusSource< I, O >( this.scrap.createVariable(), this.converter, this.kdtree, this.radius, this.outside, this.interval );
+	}
+
+	@Override
+	public RandomAccess< O > copyRandomAccess()
+	{
+		return new KDTreeRadiusSource< I, O >( this.scrap.createVariable(), this.converter, this.kdtree, this.radius, this.outside, this.interval );
+	}
+	
+	// Methods from interface RandomAccessible
+	@Override
+	public RandomAccess< O > randomAccess()
+	{
+		return this;
+	}
+
+	@Override
+	public RandomAccess< O > randomAccess( final Interval interval )
+	{
+		return this;
+	}
+	
+	// Methods from interface OFunction
+	@Override
+	public final O eval()
+	{
+		return this.cursor.next();
+	}
+
+	@Override
+	public O eval( final Localizable loc )
+	{
+		this.setPosition( loc );
+		return this.get();
+	}
+	
+	@Override
+	public List< OFunction< O > > children()
+	{
+		return Arrays.asList();
+	}
+	
+	@Override
+	public final double evalDouble()
+	{
+		return this.cursor.next().getRealDouble();
+	}
+	
+	@Override
+	public final double evalDouble( final Localizable loc )
+	{
+		this.setPosition( loc );
+		return this.get().getRealDouble();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalAnd.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalAnd.java
@@ -1,0 +1,18 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalAnd< O extends RealType< O > > extends Comparison< O >
+{	
+	public LogicalAnd( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+	}
+	
+	@Override
+	public boolean compare( final O t1, final O t2 )
+	{
+		return 0 != t1.getRealDouble() && 0 != t2.getRealDouble();
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalAndBoolean.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalAndBoolean.java
@@ -1,0 +1,30 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.IBooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalAndBoolean< O extends RealType< O > > extends LogicalAnd< O >
+{
+	private final IBooleanFunction abool, bbool;
+	
+	public LogicalAndBoolean( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+		this.abool = ( IBooleanFunction )a;
+		this.bbool = ( IBooleanFunction )b;
+	}
+
+	@Override
+	public final boolean evalBoolean()
+	{
+		return this.abool.evalBoolean() && this.bbool.evalBoolean();
+	}
+
+	@Override
+	public final boolean evalBoolean( final Localizable loc)
+	{
+		return this.abool.evalBoolean( loc ) && this.bbool.evalBoolean( loc );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalNot.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalNot.java
@@ -1,0 +1,70 @@
+package net.imglib2.algorithm.math.execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.ABooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalNot< O extends RealType< O > > extends ABooleanFunction< O >
+{
+	protected final OFunction< O > a;
+	
+	public LogicalNot( final O scrap, final OFunction< O > a )
+	{
+		super( scrap );
+		this.a = a;
+	}
+
+	@Override
+	public boolean evalBoolean()
+	{
+		// It's true if not zero, hence reverse
+		//return ! (0 != this.a.eval().getRealDouble() );
+		return 0 == this.a.eval().getRealDouble();
+	}
+
+	@Override
+	public boolean evalBoolean( final Localizable loc )
+	{
+		// It's true if not zero, hence reverse
+		//return ! (0 != this.a.eval().getRealDouble() );
+		return 0 == this.a.eval( loc ).getRealDouble();
+	}
+
+	@Override
+	public final O eval()
+	{
+		// It's true if not zero, hence reverse
+		return 0 == this.a.eval().getRealDouble() ? one : zero;
+	}
+
+	@Override
+	public final O eval( final Localizable loc )
+	{
+		// It's true if not zero, hence reverse
+		return 0 == this.a.eval( loc ).getRealDouble() ? one : zero;
+	}
+
+	@Override
+	public final List< OFunction< O > > children()
+	{
+		return Arrays.asList( this.a );
+	}
+
+	@Override
+	public final double evalDouble()
+	{
+		// It's true if not zero, hence reverse
+		return 0 == this.a.eval().getRealDouble() ? 1.0 : 0.0;
+	}
+
+	@Override
+	public final double evalDouble( final Localizable loc )
+	{
+		// It's true if not zero, hence reverse
+		return 0 == this.a.eval( loc ).getRealDouble() ? 1.0 : 0.0;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalNotBoolean.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalNotBoolean.java
@@ -1,0 +1,29 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.IBooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalNotBoolean< O extends RealType< O > > extends LogicalNot< O >
+{
+	private final IBooleanFunction abool;
+	
+	public LogicalNotBoolean( final O scrap, final OFunction< O > a )
+	{
+		super( scrap, a );
+		this.abool = ( IBooleanFunction )a;
+	}
+
+	@Override
+	public final boolean evalBoolean()
+	{
+		return !this.abool.evalBoolean();
+	}
+
+	@Override
+	public final boolean evalBoolean( final Localizable loc )
+	{
+		return !this.abool.evalBoolean( loc );
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalOr.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalOr.java
@@ -1,0 +1,21 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalOr< O extends RealType< O > > extends Comparison< O >
+{	
+	public LogicalOr( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+	}
+	
+	@Override
+	public boolean compare( final O t1, final O t2 )
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = 0 != t1.getRealDouble(),
+					  second = 0 != t2.getRealDouble();
+		return first || second;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalOrBoolean.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalOrBoolean.java
@@ -1,0 +1,36 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.IBooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalOrBoolean< O extends RealType< O > > extends LogicalAnd< O >
+{
+	private final IBooleanFunction abool, bbool;
+	
+	public LogicalOrBoolean( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+		this.abool = ( IBooleanFunction )a;
+		this.bbool = ( IBooleanFunction )b;
+	}
+
+	@Override
+	public final boolean evalBoolean()
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = this.abool.evalBoolean(),
+					  second = this.bbool.evalBoolean();
+		return first || second;
+	}
+
+	@Override
+	public final boolean evalBoolean( final Localizable loc)
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = this.abool.evalBoolean( loc ),
+					  second = this.bbool.evalBoolean( loc );
+		return first || second;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalXor.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalXor.java
@@ -1,0 +1,21 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalXor< O extends RealType< O > > extends Comparison< O >
+{	
+	public LogicalXor( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+	}
+	
+	@Override
+	public boolean compare( final O t1, final O t2 )
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = 0 != t1.getRealDouble(),
+					  second = 0 != t2.getRealDouble();
+		return first ^ second;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/LogicalXorBoolean.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/LogicalXorBoolean.java
@@ -1,0 +1,36 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.IBooleanFunction;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public class LogicalXorBoolean< O extends RealType< O > > extends LogicalAnd< O >
+{
+	private final IBooleanFunction abool, bbool;
+	
+	public LogicalXorBoolean( final O scrap, final OFunction< O > a, final OFunction< O > b )
+	{
+		super( scrap, a, b );
+		this.abool = ( IBooleanFunction )a;
+		this.bbool = ( IBooleanFunction )b;
+	}
+
+	@Override
+	public final boolean evalBoolean()
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = this.abool.evalBoolean(),
+					  second = this.bbool.evalBoolean();
+		return first ^ second;
+	}
+
+	@Override
+	public final boolean evalBoolean( final Localizable loc)
+	{
+		// Evaluate both first, otherwise second may not get evaluated and its cursors not advanced
+		final boolean first = this.abool.evalBoolean( loc ),
+					  second = this.bbool.evalBoolean( loc );
+		return first ^ second;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/NumericSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/NumericSource.java
@@ -51,4 +51,16 @@ public class NumericSource< O extends RealType< O > > implements OFunction< O >
 	{
 		return this.number.doubleValue();
 	}
+	
+	@Override
+	public boolean isOne()
+	{
+		return 1.0 == this.number.doubleValue();
+	}
+	
+	@Override
+	public boolean isZero()
+	{
+		return 0.0 == this.number.doubleValue();
+	}
 }

--- a/src/main/java/net/imglib2/algorithm/math/execution/OffsetReading.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/OffsetReading.java
@@ -1,0 +1,67 @@
+package net.imglib2.algorithm.math.execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.algorithm.math.abstractions.RandomAccessOnly;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+public class OffsetReading< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
+{
+	private final RandomAccessible< I > src;
+	protected final RandomAccess< I > ra;
+	protected final O scrap;
+	private final Converter< RealType< ? >, O > converter;
+	
+	public OffsetReading( final O scrap,  final Converter< RealType< ? >, O > converter, final RandomAccessible< I > src, final long[] offset )
+	{
+		this.scrap = scrap;
+		this.src = src;
+		this.converter = converter;
+		this.ra = Views.translate( src, offset ).randomAccess();
+	}
+	
+	@Override
+	public final O eval()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public O eval( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		this.converter.convert( this.ra.get(), this.scrap );
+		return this.scrap;
+	}
+	
+	@Override
+	public List< OFunction< O > > children()
+	{
+		return Arrays.asList();
+	}
+	
+	@Override
+	public final double evalDouble()
+	{
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public final double evalDouble( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		return this.ra.get().getRealDouble();
+	}
+	
+	public RandomAccessible< I > getRandomAccessible()
+	{
+		return this.src;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/OffsetReadingDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/OffsetReadingDirect.java
@@ -1,0 +1,21 @@
+package net.imglib2.algorithm.math.execution;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccessible;
+import net.imglib2.type.numeric.RealType;
+
+public class OffsetReadingDirect< O extends RealType< O > > extends OffsetReading< O, O >
+{	
+	public OffsetReadingDirect( final O scrap, final RandomAccessible< O > src, final long[] offset )
+	{
+		super( scrap, null, src, offset );
+	}
+
+	@Override
+	public final O eval( final Localizable loc )
+	{
+		this.ra.setPosition( loc );
+		this.scrap.set( this.ra.get() );
+		return this.scrap;
+	}
+}

--- a/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSource.java
@@ -12,7 +12,7 @@ import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
-public class RandomAccessibleOffsetSource< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
+public class RandomAccessibleOffsetSource< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly< I >
 {
 	private final RandomAccessible< I > src;
 	protected final RandomAccess< I > ra;

--- a/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSource.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSource.java
@@ -12,19 +12,34 @@ import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
-public class OffsetReading< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
+public class RandomAccessibleOffsetSource< I extends RealType< I >, O extends RealType< O > > implements OFunction< O >, RandomAccessOnly
 {
 	private final RandomAccessible< I > src;
 	protected final RandomAccess< I > ra;
 	protected final O scrap;
 	private final Converter< RealType< ? >, O > converter;
 	
-	public OffsetReading( final O scrap,  final Converter< RealType< ? >, O > converter, final RandomAccessible< I > src, final long[] offset )
+	public RandomAccessibleOffsetSource( final O scrap,  final Converter< RealType< ? >, O > converter, final RandomAccessible< I > src, final long[] offset )
 	{
 		this.scrap = scrap;
 		this.src = src;
 		this.converter = converter;
-		this.ra = Views.translate( src, offset ).randomAccess();
+		boolean zeros = true;
+		for ( int i = 0; i < offset.length; ++i )
+			if ( 0 != offset[ i ] )
+			{
+				zeros = false;
+				break;
+			}
+		if ( zeros )
+			this.ra = src.randomAccess();
+		else
+		{
+			final long[] offsetNegative = new long[ offset.length ];
+			for ( int i = 0; i < offset.length; ++i )
+				offsetNegative[ i ] = - offset[ i ];
+			this.ra = Views.translate( src, offsetNegative ).randomAccess();
+		}
 	}
 	
 	@Override

--- a/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSourceDirect.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/RandomAccessibleOffsetSourceDirect.java
@@ -4,9 +4,9 @@ import net.imglib2.Localizable;
 import net.imglib2.RandomAccessible;
 import net.imglib2.type.numeric.RealType;
 
-public class OffsetReadingDirect< O extends RealType< O > > extends OffsetReading< O, O >
+public class RandomAccessibleOffsetSourceDirect< O extends RealType< O > > extends RandomAccessibleOffsetSource< O, O >
 {	
-	public OffsetReadingDirect( final O scrap, final RandomAccessible< O > src, final long[] offset )
+	public RandomAccessibleOffsetSourceDirect( final O scrap, final RandomAccessible< O > src, final long[] offset )
 	{
 		super( scrap, null, src, offset );
 	}

--- a/src/main/java/net/imglib2/algorithm/math/execution/ZeroMinus.java
+++ b/src/main/java/net/imglib2/algorithm/math/execution/ZeroMinus.java
@@ -1,0 +1,49 @@
+package net.imglib2.algorithm.math.execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imglib2.Localizable;
+import net.imglib2.algorithm.math.abstractions.OFunction;
+import net.imglib2.type.numeric.RealType;
+
+public final class ZeroMinus< O extends RealType< O > > implements OFunction< O >
+{
+	final O scrap;
+	final OFunction< O > a;
+	
+	public ZeroMinus( final O scrap, final OFunction< O > a)
+	{
+		this.scrap = scrap;
+		this.a = a;
+	}
+
+	@Override
+	public final O eval() {
+		this.scrap.setZero();
+		this.scrap.sub( this.a.eval() );
+		return this.scrap;
+	}
+
+	@Override
+	public final O eval(Localizable loc) {
+		this.scrap.setZero();
+		this.scrap.sub( this.a.eval( loc ) );
+		return this.scrap;
+	}
+
+	@Override
+	public List< OFunction< O > > children() {
+		return Arrays.asList( this.a );
+	}
+
+	@Override
+	public final double evalDouble() {
+		return -this.a.evalDouble();
+	}
+
+	@Override
+	public double evalDouble(Localizable loc) {
+		return -this.a.evalDouble();
+	}
+}

--- a/src/test/java/net/imglib2/algorithm/math/ImgMathTest.java
+++ b/src/test/java/net/imglib2/algorithm/math/ImgMathTest.java
@@ -811,7 +811,6 @@ public class ImgMathTest
 		  return true;
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Test
 	public void test10Logical() {
 		System.out.println("test10Logical");
@@ -842,18 +841,18 @@ public class ImgMathTest
 									  img4 = into4x4Img( pixels4 );
 		
 		// AND
-		assertTrue( same( img1, ( Img< UnsignedByteType > )compute(AND(img1, img2)).intoArrayImg() ) );
+		assertTrue( same( img1, compute(AND(img1, img2)).intoArrayImg( new UnsignedByteType() ) ) );
 		// OR
-		assertTrue( same( img2, ( Img< UnsignedByteType > )compute(OR(img1, img2)).intoArrayImg() ) );
+		assertTrue( same( img2, compute(OR(img1, img2)).intoArrayImg( new UnsignedByteType() ) ) );
 		// XOR
-		assertTrue( same( img3, ( Img< UnsignedByteType > )compute(XOR(img1, img2)).intoArrayImg() ) );
+		assertTrue( same( img3, compute(XOR(img1, img2)).intoArrayImg( new UnsignedByteType() ) ) );
 		// NOT
-		assertTrue( same( img4, ( Img< UnsignedByteType > )compute(NOT(img1)).intoArrayImg() ) );
+		assertTrue( same( img4, compute(NOT(img1)).intoArrayImg( new UnsignedByteType() ) ) );
 		
 		// Test LogicalAndBoolean
 		final Img< UnsignedByteType> imgIFAND = ( Img< UnsignedByteType> )compute(IF(AND(LT(img1, 1), LT(img2, 1)),
 		                     THEN(1),
-		                     ELSE(0))).intoArrayImg();
+		                     ELSE(0))).intoArrayImg( new UnsignedByteType() );
 
 		final byte[] pixels5 = new byte[ pixels1.length ];
 		for ( int i = 0; i < pixels1.length; ++i )


### PR DESCRIPTION
Additional features for ImgMath, including:

  * Ability to take a ```RandomAccessible``` as input, which enables e.g. offset reading, to create e.g. convolution filters or integral images (by reading from the prior pixel and writing onto the same image as the source).
  * Ability to do block reads by reading the values from 4 corners and combining them, namely for reading ```IntegralImg``` or any other form of integral image (also known as sum area tables) expressed as a ```RandomAccessible```.
  * Ability to prune away null ops, such as adding zero, subtracting zero, dividing by 1, multiplying by 1, multiplying by 0, exponentiating (power) to 1, exponentiating a 1, and others. Simplifies operations which increases performance, and, critically, simplifying writing code to generate e.g. convolution filters.
  * Ability to take a ```KDTree``` plus a radius as input.
  * New operation minus, equivalent to sub(0, value), to add a minus sign to a value.
  * New operations log and exp, based on ```Math.log``` and ```Math.exp```, not based on ```NumericType``` math because this type lacks these functions.
  * Small utility functions.