### PR TITLE
Move tests to correct package

### DIFF
--- a/src/test/java/net/imglib2/algorithm/labeling/AllConnectedComponentsTest.java
+++ b/src/test/java/net/imglib2/algorithm/labeling/AllConnectedComponentsTest.java
@@ -32,7 +32,7 @@
  * #L%
  */
 
-package tests.labeling;
+package net.imglib2.algorithm.labeling;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/net/imglib2/algorithm/labeling/ConnectedComponentsTest.java
+++ b/src/test/java/net/imglib2/algorithm/labeling/ConnectedComponentsTest.java
@@ -32,7 +32,7 @@
  * #L%
  */
 
-package tests.labeling;
+package net.imglib2.algorithm.labeling;
 
 import static net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement.EIGHT_CONNECTED;
 import static net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement.FOUR_CONNECTED;

--- a/src/test/java/net/imglib2/algorithm/labeling/WatershedTest.java
+++ b/src/test/java/net/imglib2/algorithm/labeling/WatershedTest.java
@@ -32,7 +32,7 @@
  * #L%
  */
 
-package tests.labeling;
+package net.imglib2.algorithm.labeling;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Some labeling-related unit tests where in java/tests/ instead of java/net/imglib2/algorithm/labeling/, I moved them to the correct folder and updated the package.