### PR TITLE
Add Op discovery annotations to ImgLib2-algorithm

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,22 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<imglib2-roi.version>0.15.0</imglib2-roi.version>
 		<imglib2-cache.version>1.0.0-beta-18</imglib2-cache.version>
 		<sc.fiji.bigdataviewer-core.version>10.4.16</sc.fiji.bigdataviewer-core.version>
+
+		<!--
+		NB: Older versions of OpenJDK 11 have a bug in the javadoc tool,
+		which causes errors like:
+
+		[ERROR] javadoc: error - The code being documented uses packages
+		in the unnamed module, but the packages defined in
+		https://github.com/scijava/scijava/apidocs/ are in named modules.
+
+		The most recent version of OpenJDK 11 known to have this problem
+		is 11.0.8; the oldest version known to have fixed it is 11.0.17.
+		Therefore, we set the minimum build JDK version to 11.0.17 here.
+		-->
+		<scijava.jvm.build.version>[11.0.17,)</scijava.jvm.build.version>
+		<scijava.jvm.version>8</scijava.jvm.version>
+		<scijava.parse.ops>true</scijava.parse.ops>
 	</properties>
 
 	<repositories>
@@ -281,4 +297,39 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<!-- TODO: Remove relevant sections once upstream -->
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.scijava</groupId>
+							<artifactId>scijava-ops-indexer</artifactId>
+							<version>1.0.0</version>
+						</path>
+					</annotationProcessorPaths>
+					<fork>true</fork>
+					<compilerArgs>
+						<arg>-Ascijava.ops.parse=${scijava.parse.ops}</arg>
+						<arg>-Ascijava.ops.opVersion=${project.version}</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<tags>
+						<tag>
+							<name>implNote</name>
+							<placement>a</placement>
+							<head>Implementation Note:</head>
+						</tag>
+					</tags>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/net/imglib2/algorithm/binary/Thresholder.java
+++ b/src/main/java/net/imglib2/algorithm/binary/Thresholder.java
@@ -70,6 +70,7 @@ public class Thresholder
 	 *            the number of threads to use for thresholding.
 	 * @return a new {@link Img} of type {@link BitType} and of same dimension
 	 *         that the source image.
+	 * @implNote op name='threshold.apply'
 	 */
 	public static final < T extends Type< T > & Comparable< T >> Img< BitType > threshold( final Img< T > source, final T threshold, final boolean above, final int numThreads )
 	{

--- a/src/main/java/net/imglib2/algorithm/componenttree/mser/MserTree.java
+++ b/src/main/java/net/imglib2/algorithm/componenttree/mser/MserTree.java
@@ -105,7 +105,8 @@ public final class MserTree< T extends Type< T > > implements ComponentForest< M
 	 * {@link #buildMserTree(RandomAccessibleInterval, RealType, long, long, double, double, ImgFactory, boolean)}
 	 * using an {@link ArrayImgFactory} or {@link CellImgFactory} depending on
 	 * input image size.
-	 * 
+	 *
+	 * @implNote op name='create.mserTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param delta
@@ -133,7 +134,8 @@ public final class MserTree< T extends Type< T > > implements ComponentForest< M
 	 * {@link #buildMserTree(RandomAccessibleInterval, RealType, long, long, double, double, ImgFactory, boolean)}
 	 * using an {@link ArrayImgFactory} or {@link CellImgFactory} depending on
 	 * input image size.
-	 * 
+	 *
+	 * @implNote op name='create.mserTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param delta
@@ -159,7 +161,8 @@ public final class MserTree< T extends Type< T > > implements ComponentForest< M
 
 	/**
 	 * Build a MSER tree from an input image.
-	 * 
+	 *
+	 * @implNote op name='create.mserTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param delta
@@ -198,7 +201,8 @@ public final class MserTree< T extends Type< T > > implements ComponentForest< M
 	 * {@link #buildMserTree(RandomAccessibleInterval, ComputeDelta, long, long, double, double, ImgFactory, Type, Comparator)}
 	 * using an {@link ArrayImgFactory} or {@link CellImgFactory} depending on
 	 * input image size.
-	 * 
+	 *
+	 * @implNote op name='create.mserTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param computeDelta
@@ -226,7 +230,8 @@ public final class MserTree< T extends Type< T > > implements ComponentForest< M
 
 	/**
 	 * Build a MSER tree from an input image.
-	 * 
+	 *
+	 * @implNote op name='create.mserTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param computeDelta

--- a/src/main/java/net/imglib2/algorithm/componenttree/pixellist/PixelListComponentTree.java
+++ b/src/main/java/net/imglib2/algorithm/componenttree/pixellist/PixelListComponentTree.java
@@ -74,6 +74,7 @@ public final class PixelListComponentTree< T extends Type< T > > implements Comp
 	 * using an {@link ArrayImgFactory} or {@link CellImgFactory} depending on
 	 * input image size.
 	 *
+	 * @implNote op name='create.pixelListComponentTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param type
@@ -92,6 +93,7 @@ public final class PixelListComponentTree< T extends Type< T > > implements Comp
 	/**
 	 * Build a component tree from an input image.
 	 *
+	 * @implNote op name='create.pixelListComponentTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param type
@@ -120,6 +122,7 @@ public final class PixelListComponentTree< T extends Type< T > > implements Comp
 	 * using an {@link ArrayImgFactory} or {@link CellImgFactory} depending on
 	 * input image size.
 	 *
+	 * @implNote op name='create.pixelListComponentTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param maxValue
@@ -138,6 +141,7 @@ public final class PixelListComponentTree< T extends Type< T > > implements Comp
 	/**
 	 * Build a component tree from an input image.
 	 *
+	 * @implNote op name='create.pixelListComponentTree',type=Function
 	 * @param input
 	 *            the input image.
 	 * @param maxValue

--- a/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/fast_gauss/FastGauss.java
@@ -88,11 +88,23 @@ public class FastGauss
 		return new LineConvolution<>( new FastGaussConvolverRealType( sigma ), direction );
 	}
 
+	/**
+	 * @param sigmas the standard deviations of the Gaussian blur (in each dimension)
+	 * @param input the input data to blur
+	 * @param output the preallocated output buffer
+	 * @implNote op name='filter.gauss', type=Computer
+	 */
 	public static void convolve( final double[] sigmas, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
 	{
 		convolution( sigmas ).process( input, output );
 	}
 
+	/**
+	 * @param sigma the standard deviation of the Gaussian blur (in all dimensions)
+	 * @param input the input data to blur
+	 * @param output the preallocated output buffer
+	 * @implNote op name='filter.gauss', type=Computer
+	 */
 	public static void convolve( final double sigma, final RandomAccessible< ? extends RealType< ? > > input, final RandomAccessibleInterval< ? extends RealType< ? > > output )
 	{
 		convolution( sigma ).process( input, output );

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/Kernel1D.java
@@ -56,6 +56,8 @@ public class Kernel1D
 	 * @param halfKernel
 	 *            the upper half (starting at the center pixel) of the symmetric
 	 *            convolution kernel.
+	 * @return a {@link Kernel1D} used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DSymmetric'
 	 */
 	public static Kernel1D symmetric( final double... halfKernel )
 	{
@@ -68,6 +70,9 @@ public class Kernel1D
 	/**
 	 * Similar to {@link #symmetric(double[])} but creates an array of
 	 * one-dimensional convolution kernels.
+	 * @param halfKernels the upper halves (starting at the center pixel) of the symmetric convolution kernels
+	 * @return an array of {@link Kernel1D}s used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DSymmetric'
 	 */
 	public static Kernel1D[] symmetric( final double[][] halfKernels )
 	{
@@ -82,6 +87,8 @@ public class Kernel1D
 	 * @param originIndex
 	 *            the index of the array element which is the origin of the
 	 *            kernel
+	 * @return an asymmetric {@link Kernel1D} used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DAsymmetric'
 	 */
 	public static Kernel1D asymmetric( final double[] fullKernel, final int originIndex )
 	{
@@ -94,6 +101,9 @@ public class Kernel1D
 	/**
 	 * Creates a one-dimensional asymmetric convolution kernel, where the origin
 	 * of the kernel is in the middle.
+	 * @param kernel the raw data of the symmetric convolution kernel
+	 * @return a {@link Kernel1D} used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DCentralAsymmetric'
 	 */
 	public static Kernel1D centralAsymmetric( final double... kernel )
 	{
@@ -103,6 +113,13 @@ public class Kernel1D
 	/**
 	 * Similar to {@link #asymmetric(double[], int)} but creates an array of
 	 * one-dimensional convolution kernels.
+	 * @param fullKernels
+	 *            arrays containing the values of each kernel
+	 * @param originIndices
+	 *            the indices of the array elements at the origin of each
+	 *            kernel
+	 * @return an array of {@link Kernel1D}s used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DAsymmetric'
 	 */
 	public static Kernel1D[] asymmetric( final double[][] fullKernels, final int[] originIndices )
 	{
@@ -113,6 +130,9 @@ public class Kernel1D
 	/**
 	 * Similar to {@link #centralAsymmetric(double...)} but creates an array of
 	 * one-dimensional convolution kernels.
+	 * @param kernels the upper halves (starting at the center pixel) of the symmetric convolution kernels
+	 * @return an array of {@link Kernel1D}s used for one dimensional convolutions
+	 * @implNote op name='create.kernel1DCentralAsymmetric'
 	 */
 	public static Kernel1D[] centralAsymmetric( final double[][] kernels )
 	{

--- a/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/convolution/kernel/SeparableKernelConvolution.java
@@ -114,6 +114,7 @@ public class SeparableKernelConvolution
 	 *            the required source interval.
 	 * @param target
 	 *            target image.
+	 * @implNote op name='filter.convolve', type=Computer
 	 */
 	public static void convolve( final Kernel1D[] kernels,
 			final RandomAccessible< ? extends NumericType< ? > > source,

--- a/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
+++ b/src/main/java/net/imglib2/algorithm/dog/DifferenceOfGaussian.java
@@ -69,6 +69,44 @@ public class DifferenceOfGaussian
 	 * {@link #DoG(double[], double[], RandomAccessible, RandomAccessible, RandomAccessibleInterval, ExecutorService)}
 	 * .
 	 * </p>
+	 * This method differs from
+	 * {@link #DoG(double[], double[], RandomAccessible, RandomAccessibleInterval, ExecutorService)}
+	 * only in that its parameter order is tailored to an Op. The output comes
+	 * last, and the primary input (the input image) comes first.
+	 *
+	 * @implNote op name="filter.DoG", type=Computer
+	 * @param input
+	 *            the input image extended to infinity (or at least covering the
+	 *            same interval as the dog result image, plus borders for
+	 *            convolution).
+	 * @param sigmaSmaller
+	 *            stddev (in every dimension) of smaller Gaussian.
+	 * @param sigmaLarger
+	 *            stddev (in every dimension) of larger Gaussian.
+	 * @param service
+	 *            service providing threads for multi-threading
+	 * @param dog
+	 *            the Difference-of-Gaussian result image.
+	 */
+	public static < I extends NumericType< I >, T extends NumericType< T > & NativeType< T > > void DoG(
+			final RandomAccessible< I > input,
+			final double[] sigmaSmaller,
+			final double[] sigmaLarger,
+			final ExecutorService service,
+			final RandomAccessibleInterval< T > dog)
+	{
+		DoG( sigmaSmaller, sigmaLarger, input, dog, service );
+	}
+
+	/**
+	 * Compute the difference of Gaussian for the input. Input convolved with
+	 * Gaussian of sigmaSmaller is subtracted from input convolved with Gaussian
+	 * of sigmaLarger (where {@code sigmaLarger > sigmaSmaller}).
+	 * <p>
+	 * Creates an appropriate temporary image and calls
+	 * {@link #DoG(double[], double[], RandomAccessible, RandomAccessible, RandomAccessibleInterval, ExecutorService)}
+	 * .
+	 * </p>
 	 *
 	 * @param sigmaSmaller
 	 *            stddev (in every dimension) of smaller Gaussian.
@@ -95,6 +133,44 @@ public class DifferenceOfGaussian
 		final long[] translation = new long[ dog.numDimensions() ];
 		dog.min( translation );
 		DoG( sigmaSmaller, sigmaLarger, input, Views.translate( g1, translation ), dog, service );
+	}
+
+	/**
+	 * Compute the difference of Gaussian for the input. Input convolved with
+	 * Gaussian of sigmaSmaller is subtracted from input convolved with Gaussian
+	 * of sigmaLarger (where sigmaLarger &gt; sigmaSmaller).
+	 * </p>
+	 * This method differs from
+	 * {@link #DoG(double[], double[], RandomAccessible, RandomAccessible, RandomAccessibleInterval, ExecutorService)}
+	 * only in that its parameter order is tailored to an Op. The output comes
+	 * last, and the primary input (the input image) comes first.
+	 *
+	 * @implNote op name="filter.DoG", type=Computer
+	 * @param input
+	 *            the input image extended to infinity (or at least covering the
+	 *            same interval as the dog result image, plus borders for
+	 *            convolution).
+	 * @param sigmaSmaller
+	 *            stddev (in every dimension) of smaller Gaussian.
+	 * @param sigmaLarger
+	 *            stddev (in every dimension) of larger Gaussian.
+	 * @param tmp
+	 *            temporary image, must at least cover the same interval as the
+	 *            dog result image.
+	 * @param service
+	 *            how many threads to use for the computation.
+	 * @param dog
+	 *            the Difference-of-Gaussian result image.
+	 */
+	public static < I extends NumericType< I >, T extends NumericType< T > & NativeType< T > > void DoG(
+			final RandomAccessible< I > input,
+			final double[] sigmaSmaller,
+			final double[] sigmaLarger,
+			final RandomAccessible< T > tmp,
+			final ExecutorService service,
+			final RandomAccessibleInterval< T > dog)
+	{
+		DoG(sigmaSmaller, sigmaLarger, input, tmp, dog, service);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/algorithm/edge/SubpixelEdgelDetection.java
+++ b/src/main/java/net/imglib2/algorithm/edge/SubpixelEdgelDetection.java
@@ -73,7 +73,8 @@ public class SubpixelEdgelDetection
 	 * <p>
 	 * Note: The input image type must be a signed type! Otherwise gradient
 	 * computation will not work.
-	 * 
+	 *
+	 * @implNote op name='image.subpixelEdgels', type=Function
 	 * @param input
 	 *            input image
 	 * @param factory

--- a/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
+++ b/src/main/java/net/imglib2/algorithm/fill/FloodFill.java
@@ -90,6 +90,7 @@ public class FloodFill
 	 *            input pixel type
 	 * @param <U>
 	 *            fill label type
+	 * @implNote op name='image.floodFill', type=Computer2
 	 */
 	public static < T extends Type< T >, U extends Type< U > > void fill(
 			final RandomAccessible< T > source,
@@ -138,6 +139,7 @@ public class FloodFill
 	 *            input pixel type
 	 * @param <U>
 	 *            fill label type
+	 * @implNote op name='image.floodFill', type=Computer2
 	 */
 	public static < T, U extends Type< U > > void fill(
 			final RandomAccessible< T > source,
@@ -180,6 +182,7 @@ public class FloodFill
 	 *            input pixel type
 	 * @param <U>
 	 *            fill label type
+	 * @implNote op name='image.floodFill', type=Computer2
 	 */
 	public static < T, U > void fill(
 			final RandomAccessible< T > source,

--- a/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
+++ b/src/main/java/net/imglib2/algorithm/gauss3/Gauss3.java
@@ -74,6 +74,7 @@ public final class Gauss3
 	 * {@link Parallelization} context. (By default, it will use the
 	 * {@link ForkJoinPool#commonPool() common ForkJoinPool})
 	 *
+	 * @implNote op name='filter.gauss', type=Computer
 	 * @param sigma
 	 *            standard deviation of isotropic Gaussian.
 	 * @param source
@@ -116,6 +117,7 @@ public final class Gauss3
 	 * {@link Parallelization} context. (By default, it will use the
 	 * {@link ForkJoinPool#commonPool() common ForkJoinPool})
 	 *
+	 * @implNote op name='filter.gauss', type=Computer
 	 * @param sigma
 	 *            standard deviation in every dimension.
 	 * @param source

--- a/src/main/java/net/imglib2/algorithm/gradient/PartialDerivative.java
+++ b/src/main/java/net/imglib2/algorithm/gradient/PartialDerivative.java
@@ -107,6 +107,7 @@ public class PartialDerivative
 	 * @param es
 	 *            {@link ExecutorService} providing workers for gradient
 	 *            computation. Service is managed (created, shutdown) by caller.
+	 * @implNote op name='filter.partialDerivative, filter.gradientCentralDifference', type=Computer2, priority='-1000.'
 	 */
 	public static < T extends NumericType< T > > void gradientCentralDifferenceParallel(
 			final RandomAccessible< T > source,
@@ -177,6 +178,7 @@ public class PartialDerivative
 	 *            output image
 	 * @param dimension
 	 *            along which dimension the partial derivatives are computed
+	 * @implNote op name='filter.partialDerivative, filter.gradientCentralDifference', type=Computer2, priority='-1000.'
 	 */
 	public static < T extends NumericType< T > > void gradientCentralDifference( final RandomAccessible< T > source,
 			final RandomAccessibleInterval< T > result, final int dimension )
@@ -200,6 +202,7 @@ public class PartialDerivative
 	 *            the gradient image plus a one pixel border in dimension.
 	 * @param result output image
 	 * @param dimension along which dimension the partial derivatives are computed
+	 * @implNote op name='filter.gradientBackwardDifference', type=Computer2
 	 */
 	public static < T extends NumericType< T > > void gradientBackwardDifference( final RandomAccessible< T > source,
 			final RandomAccessibleInterval< T > result, final int dimension )
@@ -222,6 +225,7 @@ public class PartialDerivative
 	 *            the gradient image plus a one pixel border in dimension.
 	 * @param result output image
 	 * @param dimension along which dimension the partial derivatives are computed
+	 * @implNote op name='filter.gradientForwardDifference', type=Computer2
 	 */
 	public static < T extends NumericType< T > > void gradientForwardDifference( final RandomAccessible< T > source,
 			final RandomAccessibleInterval< T > result, final int dimension )

--- a/src/main/java/net/imglib2/algorithm/hough/HoughTransforms.java
+++ b/src/main/java/net/imglib2/algorithm/hough/HoughTransforms.java
@@ -106,6 +106,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * Returns the size of the vote space output image given an input
 	 * {@link RandomAccessibleInterval}.
 	 *
+	 * @implNote op names='features.hough.getVotespaceSize', type=Function
 	 * @param dimensions
 	 *            - the {@link Dimensions} over which the Hough Line Transform
 	 *            will be run
@@ -120,6 +121,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * Returns the size of the vote space output image given an input
 	 * {@link RandomAccessibleInterval}.
 	 *
+	 * @implNote op names='features.hough.getVotespaceSize', type=Function
 	 * @param dimensions
 	 *            - the {@link Dimensions} over which the Hough Line Transform
 	 *            will be run
@@ -136,6 +138,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * Returns the size of the voteSpace output image given desired {@code nRho}
 	 * and {@code nTheta} values.
 	 *
+	 * @implNote op names='features.hough.getVotespaceSize', type=Function
 	 * @param nRho
 	 *            - the number of bins for rho resolution
 	 * @param nTheta
@@ -150,6 +153,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	/**
 	 * Pick vote space peaks with a {@link LocalExtrema}.
 	 *
+	 * @implNote op names='features.hough.pickPeaks', type=Function
 	 * @param voteSpace
 	 *            - the {@link RandomAccessibleInterval} containing the output
 	 *            of a Hough Transform vote
@@ -171,6 +175,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	/**
 	 * Pick vote space peaks with a {@link LocalExtrema}.
 	 *
+	 * @implNote op names='features.hough.pickPeaks', type=Function
 	 * @param voteSpace
 	 *            - the {@link RandomAccessibleInterval} containing the output
 	 *            of a Hough Transform vote
@@ -202,6 +207,8 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * Runs a Hough Line Tranform on an image and populates the vote space
 	 * parameter with the results.
 	 *
+	 * @implNote op names='features.hough.voteLines',
+	 *           type=Computer
 	 * @param input
 	 *            - the {@link RandomAccessibleInterval} to run the Hough Line
 	 *            Transform over
@@ -228,6 +235,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 *            are stored
 	 * @param nTheta
 	 *            - the number of bins for theta resolution
+	 * @implNote op name='features.hough.voteLines', type=Computer2
 	 */
 	public static < T extends Comparable< T >, U extends IntegerType< U > > void voteLines(
 			final RandomAccessibleInterval< T > input,
@@ -272,6 +280,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 *            - the number of bins for theta resolution
 	 * @param nRho
 	 *            - the number of bins for rho resolution
+	 * @implNote op names='features.hough.voteLines', type=Computer2
 	 */
 	public static < T extends Comparable< T >, U extends IntegerType< U > > void voteLines(
 			final RandomAccessibleInterval< T > input,
@@ -299,6 +308,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * @param threshold
 	 *            - the minimum value allowed by the populator. Any input less
 	 *            than this value will be disregarded by the populator.
+	 * @implNote op name='features.hough.voteLines', type=Computer2
 	 */
 	public static < T extends Comparable< T >, U extends IntegerType< U > > void voteLines(
 			final RandomAccessibleInterval< T > input,
@@ -366,6 +376,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 *            above the minimum value allowed by the populator. Any input
 	 *            less than or equal to this value will be disregarded by the
 	 *            populator.
+	 * @implNote op name='features.hough.voteLines', type=Computer2
 	 */
 	public static < T, U extends IntegerType< U > > void voteLines(
 			final RandomAccessibleInterval< T > input,
@@ -431,6 +442,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * y-intercept value. Used with {@link HoughTransforms#getSlope} to create
 	 * line equations.
 	 *
+	 * @implNote op name='features.hough.intercept', type=Function
 	 * @param rho
 	 *            - the {@code rho} of the line
 	 * @param theta
@@ -449,6 +461,7 @@ public class HoughTransforms< T extends RealType< T > & Comparable< T > >
 	 * value. Used with {@link HoughTransforms#getIntercept} to create line
 	 * equations.
 	 *
+	 * @implNote op name='features.hough.slope', type=Function
 	 * @param theta
 	 *            - the {@code theta} of the line
 	 * @return {@code double} - the y-intercept of the line

--- a/src/main/java/net/imglib2/algorithm/kdtree/ConvexPolytope.java
+++ b/src/main/java/net/imglib2/algorithm/kdtree/ConvexPolytope.java
@@ -65,6 +65,7 @@ public class ConvexPolytope extends AbstractEuclideanSpace
 	/**
 	 * Apply an {@link AffineGet affine transformation} to a {@link HyperPlane}.
 	 *
+	 * @implNote op name='transform.affine', type=Function
 	 * @param polytope
 	 *            a polytope.
 	 * @param transform

--- a/src/main/java/net/imglib2/algorithm/kdtree/HyperPlane.java
+++ b/src/main/java/net/imglib2/algorithm/kdtree/HyperPlane.java
@@ -74,6 +74,7 @@ public class HyperPlane extends AbstractEuclideanSpace
 	/**
 	 * Apply an {@link AffineGet affine transformation} to a {@link HyperPlane}.
 	 *
+	 * @implNote op name='transform.affine', type=Function
 	 * @param plane
 	 *            a plane.
 	 * @param transform

--- a/src/main/java/net/imglib2/algorithm/labeling/ConnectedComponentAnalysis.java
+++ b/src/main/java/net/imglib2/algorithm/labeling/ConnectedComponentAnalysis.java
@@ -117,6 +117,7 @@ public class ConnectedComponentAnalysis
 	 * generalization for higher dimenions over a binary mask. {@code mask} and
 	 * {@code labeling} are expected to have equal min and max.
 	 *
+	 * @implNote op name='labeling.cca', type=Computer
 	 * @param mask
 	 *            Boolean mask to distinguish foreground ({@code true}) from
 	 *            background ({@code false}).
@@ -154,6 +155,7 @@ public class ConnectedComponentAnalysis
 	 *            ({@link DiamondShape}), 8-neighborhood
 	 *            ({@link RectangleNeighborhood}) and their generalisations for
 	 *            higher dimensions.
+	 * @implNote op name='labeling.cca', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, L extends IntegerType< L > > void connectedComponents(
 			final RandomAccessibleInterval< B > mask,
@@ -200,6 +202,7 @@ public class ConnectedComponentAnalysis
 	 * @param idForSet
 	 *            Create id for a set from the root id of a set. Multiple calls
 	 *            with the same argument should always return the same result.
+	 * @implNote op name='labeling.cca', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, L extends IntegerType< L > > void connectedComponents(
 			final RandomAccessibleInterval< B > mask,

--- a/src/main/java/net/imglib2/algorithm/labeling/ConnectedComponents.java
+++ b/src/main/java/net/imglib2/algorithm/labeling/ConnectedComponents.java
@@ -99,6 +99,7 @@ public final class ConnectedComponents
 	 * @param se
 	 *            structuring element to use. 8-connected or 4-connected
 	 *            (respectively n-dimensional analog)
+	 * @implNote op name='labeling.cca', type=Computer2
 	 */
 	public static < T extends IntegerType< T >, L, I extends IntegerType< I > > void labelAllConnectedComponents(
 			final RandomAccessible< T > input,
@@ -132,6 +133,7 @@ public final class ConnectedComponents
 	 *            (respectively n-dimensional analog)
 	 * @param service
 	 *            service providing threads for multi-threading
+	 * @implNote op name='labeling.cca', type=Computer2
 	 */
 	public static < T extends IntegerType< T >, L, I extends IntegerType< I > > void labelAllConnectedComponents(
 			final RandomAccessible< T > input,

--- a/src/main/java/net/imglib2/algorithm/lazy/Lazy.java
+++ b/src/main/java/net/imglib2/algorithm/lazy/Lazy.java
@@ -157,6 +157,7 @@ public class Lazy
 	 * Create a memory {@link CachedCellImg} with a cell generator
 	 * {@link Consumer}.
 	 *
+	 * @implNote op name='create.img, engine.create', type=Function
 	 * @param targetInterval
 	 * @param blockSize
 	 * @param type

--- a/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
+++ b/src/main/java/net/imglib2/algorithm/localextrema/LocalExtrema.java
@@ -167,6 +167,7 @@ public class LocalExtrema
 	 * {@code source} accordingly. The returned coordinate list is valid
 	 * for the original {@code source}.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this
 	 *            {@link RandomAccessibleInterval}
@@ -208,6 +209,7 @@ public class LocalExtrema
 	 * {@code source} accordingly. The returned coordinate list is valid
 	 * for the original {@code source}.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this
 	 *            {@link RandomAccessibleInterval}
@@ -248,6 +250,7 @@ public class LocalExtrema
 	 * The task is parallelized along the longest dimension of
 	 * {@code interval}
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema of the function defined by this
 	 *            {@link RandomAccessible}
@@ -287,6 +290,7 @@ public class LocalExtrema
 	 * test for being an extremum can be specified as an implementation of the
 	 * {@link LocalNeighborhoodCheck} interface.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema of the function defined by this
 	 *            {@link RandomAccessible}
@@ -367,6 +371,7 @@ public class LocalExtrema
 	 * expand {@code source} accordingly. The returned coordinate list is
 	 * valid for the original {@code source}.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this
 	 *            {@link RandomAccessibleInterval}
@@ -393,6 +398,7 @@ public class LocalExtrema
 	 * {@code source} accordingly. The returned coordinate list is valid
 	 * for the original {@code source}.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this
 	 *            {@link RandomAccessibleInterval}
@@ -427,6 +433,7 @@ public class LocalExtrema
 	 *
 	 * The local neighborhood is defined as {@link RectangleShape} with span 1.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this {@link RandomAccessible}
 	 * @param interval
@@ -451,6 +458,7 @@ public class LocalExtrema
 	 * test for being an extremum can be specified as an implementation of the
 	 * {@link LocalNeighborhoodCheck} interface.
 	 *
+	 * @implNote op name='image.localExtrema', type=Function
 	 * @param source
 	 *            Find local extrema within this {@link RandomAccessible}
 	 * @param interval
@@ -495,6 +503,7 @@ public class LocalExtrema
 	 * determining by how much a {@link RandomAccessibleInterval} should be
 	 * expanded to include min and max positions in the local extrema search.
 	 *
+	 * @implNote op name='geom.borderSize', type=Function
 	 * @param shape
 	 *            Defines the local neighborhood
 	 * @param nDim
@@ -523,6 +532,7 @@ public class LocalExtrema
 	 * Shrink a {@link RandomAccessibleInterval} symmetrically, i.e. the margin
 	 * is applied both to min and max.
 	 *
+	 * @implNote op name='image.shrink', type=Function
 	 * @param source
 	 * @param margin
 	 * @return
@@ -538,6 +548,7 @@ public class LocalExtrema
 
 	/**
 	 *
+	 * @implNote op name='image.biggestDimension', type=Function
 	 * @param interval
 	 * @return The biggest dimension of interval.
 	 */

--- a/src/main/java/net/imglib2/algorithm/morphology/BlackTopHat.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/BlackTopHat.java
@@ -77,7 +77,8 @@ public class BlackTopHat
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
-	 * 
+	 *
+	 * @implNote op name='morphology.blackTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -120,7 +121,8 @@ public class BlackTopHat
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.blackTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -159,7 +161,8 @@ public class BlackTopHat
 	 * limited to flat structuring elements, only having {@code on/off} pixels,
 	 * contrary to grayscale structuring elements. This allows to simply use a
 	 * {@link Shape} as a type for these structuring elements.
-	 * 
+	 *
+	 * @implNote op name='morphology.blackTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -196,7 +199,8 @@ public class BlackTopHat
 	 * (against {@link Comparable}) than any of the value found in the source
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on {@code T extends Comparable & Sub}.
-	 * 
+	 *
+	 * @implNote op name='morphology.blackTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -261,6 +265,7 @@ public class BlackTopHat
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.blackTopHat', type=Computer2
 	 */
 	public static < T extends RealType< T > > void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -320,6 +325,7 @@ public class BlackTopHat
 	 *            sub-type of {@code T extends Comparable & Sub}, because we
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
+	 * @implNote op name='morphology.blackTopHat', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -358,6 +364,7 @@ public class BlackTopHat
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.blackTopHat', type=Computer2
 	 */
 	public static < T extends RealType< T > > void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -411,6 +418,7 @@ public class BlackTopHat
 	 *            sub-type of {@code T extends Comparable & Sub}, because we
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
+	 * @implNote op name='morphology.blackTopHat', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHat( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -451,6 +459,7 @@ public class BlackTopHat
 	 * @param <T>
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
+	 * @implNote op name='morphology.blackTopHat', type=Inplace1
 	 */
 	public static < T extends RealType< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -513,6 +522,7 @@ public class BlackTopHat
 	 *            sub-type of {@code T extends Comparable & Sub}, because we
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
+	 * @implNote op name='morphology.blackTopHat', type=Inplace1
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final List< ? extends Shape> strels, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -555,6 +565,7 @@ public class BlackTopHat
 	 * @param <T>
 	 *            the type of the source image. Must be a sub-type of
 	 *            {@code T extends RealType}.
+	 * @implNote op name='morphology.blackTopHat', type=Inplace1
 	 */
 	public static < T extends RealType< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final Shape strel, final int numThreads )
 	{
@@ -612,6 +623,7 @@ public class BlackTopHat
 	 *            sub-type of {@code T extends Comparable & Sub}, because we
 	 *            want to be able to compare pixels between themselves and to
 	 *            subtract them.
+	 * @implNote op name='morphology.blackTopHat', type=Inplace1
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void blackTopHatInPlace( final RandomAccessible< T > source, final Interval interval, final Shape strel, final T minVal, final T maxVal, final int numThreads )
 	{

--- a/src/main/java/net/imglib2/algorithm/morphology/Closing.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Closing.java
@@ -63,7 +63,8 @@ public class Closing
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strels
@@ -104,7 +105,8 @@ public class Closing
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strels
@@ -138,7 +140,8 @@ public class Closing
 	 * >Closing_(morphology)</a>.
 	 * <p>
 	 * The closing operation is simply a dilation followed by an erosion.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strel
@@ -174,7 +177,8 @@ public class Closing
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strel
@@ -238,6 +242,7 @@ public class Closing
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.close', type=Computer2
 	 */
 	public static < T extends RealType< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -300,6 +305,7 @@ public class Closing
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@code Compparable}.
+	 * @implNote op name='morphology.close', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -349,6 +355,7 @@ public class Closing
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.close', type=Computer2
 	 */
 	public static < T extends RealType< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -406,6 +413,7 @@ public class Closing
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@code Comparable}.
+	 * @implNote op name='morphology.close', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void close( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -443,7 +451,8 @@ public class Closing
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -495,7 +504,8 @@ public class Closing
 	 * image, and conversely for the min value. These normally unseen parameters
 	 * are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -546,7 +556,8 @@ public class Closing
 	 * image, and conversely for the min value. These normally unseen parameters
 	 * are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -598,7 +609,8 @@ public class Closing
 	 * image, and conversely for the min value. These normally unseen parameters
 	 * are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.close', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval

--- a/src/main/java/net/imglib2/algorithm/morphology/Dilation.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Dilation.java
@@ -76,6 +76,7 @@ public class Dilation
 	 * pixels, contrary to grayscale structuring elements. This allows to simply
 	 * use a {@link Shape} as a type for these structuring elements.
 	 *
+	 * @implNote op names='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -121,6 +122,7 @@ public class Dilation
 	 * image. This normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op names='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -160,6 +162,7 @@ public class Dilation
 	 * pixels, contrary to grayscale structuring elements. This allows to simply
 	 * use a {@link Shape} as a type for these structuring elements.
 	 *
+	 * @implNote op names='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -200,6 +203,7 @@ public class Dilation
 	 * image. This normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op names='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -259,6 +263,7 @@ public class Dilation
 	 *            the structuring element, as a list of {@link Shape}s.
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
+	 * @implNote op name='morphology.dilate', type=Computer2
 	 */
 	public static < T extends RealType< T >> void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -316,6 +321,7 @@ public class Dilation
 	 * @param <T>
 	 *            the type of the source image and the dilation result. Must be
 	 *            a sub-type of {@code T extends Comparable & Type}.
+	 * @implNote op name='morphology.dilate', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final int numThreads )
 	{
@@ -394,6 +400,7 @@ public class Dilation
 	 *            the structuring element, as a {@link Shape}.
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
+	 * @implNote op name='morphology.dilate', type=Computer2
 	 */
 	public static < T extends RealType< T >> void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -446,6 +453,7 @@ public class Dilation
 	 * @param <T>
 	 *            the type of the source image and the dilation result. Must be
 	 *            a sub-type of {@code T extends Comparable & Type}.
+	 * @implNote op name='morphology.dilate', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void dilate( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T minVal, int numThreads )
 	{
@@ -597,6 +605,7 @@ public class Dilation
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -655,6 +664,7 @@ public class Dilation
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -707,6 +717,7 @@ public class Dilation
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -767,6 +778,7 @@ public class Dilation
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.dilate', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -821,6 +833,7 @@ public class Dilation
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
 	 *
+	 * @implNote op name='morphology.dilate', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -870,6 +883,7 @@ public class Dilation
 	 * image. This normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.dilate', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -913,6 +927,7 @@ public class Dilation
 	 * <i>e.g.</i> {@link Views#extendValue(RandomAccessibleInterval, Type)}
 	 * <p>
 	 *
+	 * @implNote op name='morphology.dilate', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -965,6 +980,7 @@ public class Dilation
 	 * image. This normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.dilate', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval

--- a/src/main/java/net/imglib2/algorithm/morphology/Erosion.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Erosion.java
@@ -76,6 +76,7 @@ public class Erosion
 	 * pixels, contrary to grayscale structuring elements. This allows to simply
 	 * use a {@link Shape} as a type for these structuring elements.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -121,6 +122,7 @@ public class Erosion
 	 * normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -160,6 +162,7 @@ public class Erosion
 	 * pixels, contrary to grayscale structuring elements. This allows to simply
 	 * use a {@link Shape} as a type for these structuring elements.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -200,6 +203,7 @@ public class Erosion
 	 * normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -259,6 +263,7 @@ public class Erosion
 	 *            the structuring element, as a list of {@link Shape}s.
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends RealType< T >> void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -316,6 +321,7 @@ public class Erosion
 	 * @param <T>
 	 *            the type of the source image and the erosion result. Must be a
 	 *            sub-type of {@code T extends Comparable & Type}.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T maxVal, final int numThreads )
 	{
@@ -394,6 +400,7 @@ public class Erosion
 	 *            the structuring element, as a {@link Shape}.
 	 * @param numThreads
 	 *            the number of threads to use for the calculation.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends RealType< T >> void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -446,6 +453,7 @@ public class Erosion
 	 * @param <T>
 	 *            the type of the source image and the erosion result. Must be a
 	 *            sub-type of {@code T extends Comparable & Type}.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void erode( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T maxVal, int numThreads )
 	{
@@ -597,6 +605,7 @@ public class Erosion
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -655,6 +664,7 @@ public class Erosion
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -707,6 +717,7 @@ public class Erosion
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -767,6 +778,7 @@ public class Erosion
 	 * dimensions equals to the maximum of the number of dimension of both
 	 * source and structuring element.
 	 *
+	 * @implNote op name='morphology.erode', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -821,6 +833,7 @@ public class Erosion
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
 	 *
+	 * @implNote op name='morphology.erode', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -870,6 +883,7 @@ public class Erosion
 	 * normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.erode', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -913,6 +927,7 @@ public class Erosion
 	 * <i>e.g.</i> {@link Views#extendValue(RandomAccessibleInterval, Type)}
 	 * <p>
 	 *
+	 * @implNote op name='morphology.erode', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -962,6 +977,7 @@ public class Erosion
 	 * normally unseen parameter is required to operate on
 	 * {@code T extends Comparable & Type}.
 	 *
+	 * @implNote op name='morphology.erode', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval

--- a/src/main/java/net/imglib2/algorithm/morphology/Opening.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/Opening.java
@@ -70,7 +70,8 @@ public class Opening
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strels
@@ -111,7 +112,8 @@ public class Opening
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strels
@@ -145,7 +147,8 @@ public class Opening
 	 * >Opening_(morphology)</a>.
 	 * <p>
 	 * The opening operation is simply an erosion followed by a dilation.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strel
@@ -181,7 +184,8 @@ public class Opening
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Function
 	 * @param source
 	 *            the {@link Img} to operate on.
 	 * @param strel
@@ -245,6 +249,7 @@ public class Opening
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends RealType< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -307,6 +312,7 @@ public class Opening
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@code Compparable}.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -356,6 +362,7 @@ public class Opening
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.open', type=Computer2
 	 */
 	public static < T extends RealType< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -413,6 +420,7 @@ public class Opening
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@code Comparable}.
+	 * @implNote op name='morphology.erode', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > > void open( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -450,7 +458,8 @@ public class Opening
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is left untouched.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -502,7 +511,8 @@ public class Opening
 	 * image, and conversely for the min value. These normally unseen parameters
 	 * are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -545,7 +555,8 @@ public class Opening
 	 * It is the caller responsibility to ensure that the source is sufficiently
 	 * padded to properly cover the target range plus the shape size. See
 	 * <i>e.g.</i> {@link Views#extendValue(RandomAccessibleInterval, Type)}.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -592,7 +603,8 @@ public class Opening
 	 * image, and conversely for the min value. These normally unseen parameters
 	 * are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op name='morphology.open', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval

--- a/src/main/java/net/imglib2/algorithm/morphology/StructuringElements.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/StructuringElements.java
@@ -88,6 +88,7 @@ public class StructuringElements
 	 * This methods relies on heuristics to determine automatically what
 	 * decomposition level to use.
 	 *
+	 * @implNote op name='create.disk', type=Function
 	 * @param radius
 	 *            the radius of the disk, so that it extends over
 	 *            {@code 2 × radius + 1} in all dimensions
@@ -145,6 +146,7 @@ public class StructuringElements
 	 * select the level of approximation. For other dimensionalities, no
 	 * optimization are available yet and the parameter is ignored.
 	 *
+	 * @implNote op name='create.disk', type=Function
 	 * @param radius
 	 *            the radius of the disk, so that it extends over
 	 *            {@code 2 × radius + 1} in all dimensions
@@ -291,6 +293,7 @@ public class StructuringElements
 	 * dimensionality and target dimensionality do not match. Non-decomposed
 	 * version are dimension-generic.
 	 *
+	 * @implNote op name='create.square', type=Function
 	 * @param radius
 	 *            the radius of the square.
 	 * @param dimensionality
@@ -340,6 +343,7 @@ public class StructuringElements
 	 * This method determines whether it is worth returning a decomposed strel
 	 * based on simple heuristics.
 	 *
+	 * @implNote op name='create.square', type=Function
 	 * @param radius
 	 *            the radius of the square.
 	 * @param dimensionality
@@ -370,6 +374,7 @@ public class StructuringElements
 	 * of orthogonal lines and yield the exact same results on any of the
 	 * morphological operations.
 	 *
+	 * @implNote op name='create.rectangle', type=Function
 	 * @param halfSpans
 	 *            an {@code int[]} array containing the half-span of the
 	 *            symmetric rectangle in each dimension. The total extent of the
@@ -423,6 +428,7 @@ public class StructuringElements
 	 * morphological operations. This method uses a simple heuristic to decide
 	 * whether to decompose the rectangle or not.
 	 *
+	 * @implNote op name='create.rectangle', type=Function
 	 * @param halfSpans
 	 *            an {@code int[]} array containing the half-span of the
 	 *            symmetric rectangle in each dimension. The total extent of the
@@ -478,6 +484,7 @@ public class StructuringElements
 	 * fall back on a linear decomposition, still very effective (see [1] as
 	 * well).
 	 *
+	 * @implNote op name='create.diamond', type=Function
 	 * @param radius
 	 *            the desired radius of the diamond structuring element. The
 	 *            strel will extend over {@code 2 × radius + 1} in all
@@ -527,6 +534,7 @@ public class StructuringElements
 	 * fall back on a linear decomposition, still very effective (see [1] as
 	 * well).
 	 *
+	 * @implNote op name='create.diamond', type=Function
 	 * @param radius
 	 *            the desired radius of the diamond structuring element. The
 	 *            strel will extend over {@code 2 × radius + 1} in all
@@ -622,12 +630,14 @@ public class StructuringElements
 	 *
 	 * The importance of periodic lines is explained in [1].
 	 *
+	 * @implNote op name='create.periodicLine', type=Function
 	 * @param span
 	 *            the span of the neighborhood, so that it will iterate over
 	 *            {@code 2 × span + 1} pixels.
 	 * @param increments
 	 *            the values by which each element of the position vector is to
 	 *            be incremented when iterating.
+	 * @return a {@link Shape} structuring element.
 	 * @see <a
 	 *      href="http://www.sciencedirect.com/science/article/pii/0167865596000669">[1]</a>
 	 *      Jones and Soilles.Periodic lines: Definition, cascades, and

--- a/src/main/java/net/imglib2/algorithm/morphology/TopHat.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/TopHat.java
@@ -78,7 +78,8 @@ public class TopHat
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is returned.
 	 * <p>
-	 * 
+	 *
+	 * @implNote op names='morphology.topHat, morphology.whiteTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -122,7 +123,8 @@ public class TopHat
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Type}.
-	 * 
+	 *
+	 * @implNote op names='morphology.topHat, morphology.whiteTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strels
@@ -161,7 +163,8 @@ public class TopHat
 	 * limited to flat structuring elements, only having {@code on/off}
 	 * pixels, contrary to grayscale structuring elements. This allows to simply
 	 * use a {@link Shape} as a type for these structuring elements.
-	 * 
+	 *
+	 * @implNote op names='morphology.topHat, morphology.whiteTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -199,7 +202,8 @@ public class TopHat
 	 * image, and the converse for the max value. These normally unseen
 	 * parameters are required to operate on
 	 * {@code T extends Comparable & Sub}.
-	 * 
+	 *
+	 * @implNote op names='morphology.topHat, morphology.whiteTopHat', type=Function
 	 * @param source
 	 *            the source image.
 	 * @param strel
@@ -264,6 +268,7 @@ public class TopHat
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Computer2
 	 */
 	public static < T extends RealType< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final int numThreads )
 	{
@@ -325,6 +330,7 @@ public class TopHat
 	 *            sub-type of {@code T extends Comparable & Sub},
 	 *            because we want to be able to compare pixels between
 	 *            themselves and to subtract them.
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final List< ? extends Shape > strels, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -364,6 +370,7 @@ public class TopHat
 	 * @param <T>
 	 *            the type of the source and the result. Must extends
 	 *            {@link RealType}.
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Computer2
 	 */
 	public static < T extends RealType< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final int numThreads )
 	{
@@ -419,6 +426,7 @@ public class TopHat
 	 *            sub-type of {@code T extends Comparable & Sub},
 	 *            because we want to be able to compare pixels between
 	 *            themselves and to subtract them.
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Computer2
 	 */
 	public static < T extends Type< T > & Comparable< T > & Sub< T >> void topHat( final RandomAccessible< T > source, final IterableInterval< T > target, final Shape strel, final T minVal, final T maxVal, final int numThreads )
 	{
@@ -447,7 +455,8 @@ public class TopHat
 	 * allow for performance optimization through structuring element
 	 * decomposition. Each shape is processed in order as given in the list. If
 	 * the list is empty, the source image is left untouched.
-	 * 
+	 *
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -502,7 +511,8 @@ public class TopHat
 	 * conversely for the min value. These normally unseen parameters are
 	 * required to operate on
 	 * {@code T extends Comparable & Sub}.
-	 * 
+	 *
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -552,7 +562,8 @@ public class TopHat
 	 * It is the caller responsibility to ensure that the source is sufficiently
 	 * padded to properly cover the target range plus the shape size. See
 	 * <i>e.g.</i> {@link Views#extendValue(RandomAccessibleInterval, Type)}.
-	 * 
+	 *
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval
@@ -602,7 +613,8 @@ public class TopHat
 	 * conversely for the min value. These normally unseen parameters are
 	 * required to operate on
 	 * {@code T extends Comparable & Sub}.
-	 * 
+	 *
+	 * @implNote op name='morphology.topHat, morphology.whiteTopHat', type=Inplace1
 	 * @param source
 	 *            the source image.
 	 * @param interval

--- a/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
@@ -122,6 +122,7 @@ public class DistanceTransform
 	 *            should be squared, too).
 	 * @param <T>
 	 *            {@link RealType} input
+	 * @implNote op name='image.distanceTransform', type=Inplace1
 	 */
 	public static < T extends RealType< T > > void transform(
 			final RandomAccessibleInterval< T > source,
@@ -161,6 +162,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Inplace1
 	 */
 	public static < T extends RealType< T > > void transform(
 			final RandomAccessibleInterval< T > source,
@@ -195,6 +197,7 @@ public class DistanceTransform
 	 *            {@link RealType} input
 	 * @param <U>
 	 *            {@link RealType} intermediate results
+	 * @implNote op name='image.distanceTransform', type=Computer2
 	 */
 	public static < T extends RealType< T >, U extends RealType< U > > void transform(
 			final RandomAccessible< T > source,
@@ -239,6 +242,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Computer2
 	 */
 	public static < T extends RealType< T >, U extends RealType< U > > void transform(
 			final RandomAccessible< T > source,
@@ -279,6 +283,7 @@ public class DistanceTransform
 	 *            {@link RealType} intermediate results
 	 * @param <V>
 	 *            {@link RealType} output
+	 * @implNote op name='image.distanceTransform', type=Computer3
 	 */
 	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V > > void transform(
 			final RandomAccessible< T > source,
@@ -343,6 +348,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Computer3
 	 */
 	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V > > void transform(
 			final RandomAccessible< T > source,
@@ -383,6 +389,7 @@ public class DistanceTransform
 	 *            {@link Distance} between two points.
 	 * @param <T>
 	 *            {@link RealType} input
+	 * @implNote op name='image.distanceTransform', type=Inplace1
 	 */
 	public static < T extends RealType< T > > void transform(
 			final RandomAccessibleInterval< T > source,
@@ -415,6 +422,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Inplace1
 	 */
 	public static < T extends RealType< T > > void transform(
 			final RandomAccessibleInterval< T > source,
@@ -442,6 +450,7 @@ public class DistanceTransform
 	 *            {@link RealType} input
 	 * @param <U>
 	 *            {@link RealType} intermediate results
+	 * @implNote op name='image.distanceTransform', type=Computer2
 	 */
 	public static < T extends RealType< T >, U extends RealType< U > > void transform(
 			final RandomAccessible< T > source,
@@ -479,6 +488,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Computer2
 	 */
 	public static < T extends RealType< T >, U extends RealType< U > > void transform(
 			final RandomAccessible< T > source,
@@ -512,6 +522,7 @@ public class DistanceTransform
 	 *            {@link RealType} intermediate results
 	 * @param <V>
 	 *            {@link RealType} output
+	 * @implNote op name='image.distanceTransform', type=Computer2
 	 */
 	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V > > void transform(
 			final RandomAccessible< T > source,
@@ -583,6 +594,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', type=Computer3
 	 */
 	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V > > void transform(
 			final RandomAccessible< T > source,
@@ -646,6 +658,7 @@ public class DistanceTransform
 	 *            {@link BooleanType} binary mask input
 	 * @param <U>
 	 *            {@link RealType} intermediate results
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -688,6 +701,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -726,6 +740,7 @@ public class DistanceTransform
 	 *            {@link RealType} intermediate results
 	 * @param <V>
 	 *            {@link RealType} output
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer3
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U >, V extends RealType< V > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -779,6 +794,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer3
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U >, V extends RealType< V > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -818,6 +834,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', priority='100', type=Inplace1
 	 */
 	public static < B extends BooleanType< B > > void binaryTransform(
 			final RandomAccessibleInterval< B > source,
@@ -843,6 +860,7 @@ public class DistanceTransform
 	 *            {@link BooleanType} binary mask input
 	 * @param <U>
 	 *            {@link RealType} intermediate results
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -878,6 +896,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer2
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -909,6 +928,7 @@ public class DistanceTransform
 	 *            {@link RealType} intermediate results
 	 * @param <V>
 	 *            {@link RealType} output
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer3
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U >, V extends RealType< V > > void binaryTransform(
 			final RandomAccessible< B > source,
@@ -954,6 +974,7 @@ public class DistanceTransform
 	 * @throws ExecutionException
 	 *             if the computation threw an exception (distance transform may
 	 *             be computed only partially)
+	 * @implNote op name='image.distanceTransform', priority='100', type=Computer3
 	 */
 	public static < B extends BooleanType< B >, U extends RealType< U >, V extends RealType< V > > void binaryTransform(
 			final RandomAccessible< B > source,

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Branchpoints.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Branchpoints.java
@@ -69,11 +69,21 @@ public class Branchpoints extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, containing <b>only</b> skeleton branchpoints
+	 * @implNote op name='morphology.branchpoints'
+	 */
 	public static < T extends BooleanType< T > > Img< T > branchpoints( final Img< T > source )
 	{
 		return new Branchpoints().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.branchpoints', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void branchpoints( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Branchpoints().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Bridge.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Bridge.java
@@ -66,11 +66,21 @@ public class Bridge extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with bridges placed to join objects with only a single separating pixel.
+	 * @implNote op name='morphology.bridge'
+	 */
 	public static < T extends BooleanType< T > > Img< T > bridge( final Img< T > source )
 	{
 		return new Bridge().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.bridge', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void bridge( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Bridge().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Clean.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Clean.java
@@ -65,11 +65,21 @@ public class Clean extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with isolated pixels removed
+	 * @implNote op name='morphology.clean'
+	 */
 	public static < T extends BooleanType< T > > Img< T > clean( final Img< T > source )
 	{
 		return new Clean().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.clean', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void clean( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Clean().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Endpoints.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Endpoints.java
@@ -67,11 +67,21 @@ public class Endpoints extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, containing only the elements at the end of a skeleton
+	 * @implNote op name='morphology.endpoints'
+	 */
 	public static < T extends BooleanType< T > > Img< T > endpoints( final Img< T > source )
 	{
 		return new Endpoints().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.endpoints', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void endpoints( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Endpoints().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Fill.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Fill.java
@@ -65,11 +65,21 @@ public class Fill extends Abstract3x3TableOperation
 		return true;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with holes filled
+	 * @implNote op name='morphology.fill'
+	 */
 	public static < T extends BooleanType< T > > Img< T > fill( final Img< T > source )
 	{
 		return new Fill().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.fill', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void fill( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Fill().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Hbreak.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Hbreak.java
@@ -65,11 +65,21 @@ public class Hbreak extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with vertical bridges removed
+	 * @implNote op name='morphology.hbreak'
+	 */
 	public static < T extends BooleanType< T > > Img< T > hbreak( final Img< T > source )
 	{
 		return new Hbreak().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.hbreak', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void hbreak( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Hbreak().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Life.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Life.java
@@ -65,11 +65,21 @@ public class Life extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, operated on by a single iteration of the Game of Life
+	 * @implNote op name='morphology.life'
+	 */
 	public static < T extends BooleanType< T > > Img< T > life( final Img< T > source )
 	{
 		return new Life().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.life', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void life( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Life().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Majority.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Majority.java
@@ -66,11 +66,21 @@ public class Majority extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return an {@link Img} where each sample is equal to the majority value surrounding it in {@code source}
+	 * @implNote op name='morphology.majority'
+	 */
 	public static < T extends BooleanType< T > > Img< T > majority( final Img< T > source )
 	{
 		return new Majority().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.majority', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void majority( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Majority().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Remove.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Remove.java
@@ -66,11 +66,21 @@ public class Remove extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, keeping only the perimeter of solid objects.
+	 * @implNote op name='morphology.outline'
+	 */
 	public static < T extends BooleanType< T > > Img< T > remove( final Img< T > source )
 	{
 		return new Remove().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a prallocated output buffer
+	 * @implNote op name='morphology.outline', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void remove( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Remove().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Spur.java
@@ -57,11 +57,21 @@ import net.imglib2.util.Util;
  */
 public class Spur
 {
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with spurs removed
+	 * @implNote op name='morphology.spur'
+	 */
 	public static < T extends BooleanType< T > > Img< T > spur( final Img< T > source )
 	{
 		return new Spur2().calculate( new Spur1().calculate( source ) );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.spur', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void spur( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		final T extendedVal = target.firstElement().createVariable();

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Thicken.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Thicken.java
@@ -72,11 +72,21 @@ public class Thicken extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, where uniquely labeled objects are thickened
+	 * @implNote op name='morphology.thicken'
+	 */
 	public static < T extends BooleanType< T > > Img< T > thicken( final Img< T > source )
 	{
 		return new Thicken().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.thicken', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void thicken( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Thicken().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Thin.java
@@ -71,11 +71,21 @@ import net.imglib2.util.Util;
  */
 public class Thin
 {
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with lines in the image being thinned
+	 * @implNote op name='morphology.thin'
+	 */
 	public static < T extends BooleanType< T > > Img< T > thin( final Img< T > source )
 	{
 		return new Thin2().calculate( new Thin1().calculate( source ) );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.thin', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void thin( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		final T extendedVal = target.firstElement().createVariable();

--- a/src/main/java/net/imglib2/algorithm/morphology/table2d/Vbreak.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/table2d/Vbreak.java
@@ -65,11 +65,21 @@ public class Vbreak extends Abstract3x3TableOperation
 		return false;
 	}
 
+	/**
+	 * @param source the input data
+	 * @return a copy of {@code source}, with horizontal bridges removed
+	 * @implNote op name='morphology.vbreak'
+	 */
 	public static < T extends BooleanType< T > > Img< T > vbreak( final Img< T > source )
 	{
 		return new Vbreak().calculate( source );
 	}
 
+	/**
+	 * @param source the input data
+	 * @param target a preallocated output buffer
+	 * @implNote op name='morphology.vbreak', type=Computer
+	 */
 	public static < T extends BooleanType< T > > void vbreak( final RandomAccessible< T > source, final IterableInterval< T > target )
 	{
 		new Vbreak().calculate( source, target );

--- a/src/main/java/net/imglib2/algorithm/stats/Max.java
+++ b/src/main/java/net/imglib2/algorithm/stats/Max.java
@@ -46,11 +46,12 @@ public class Max
 {
 	/**
 	 * Find the maximum value and its position in an {@link IterableInterval}.
-	 * 
+	 *
 	 * @param iterable
 	 *            input interval.
 	 * @return a cursor positioned on the global maximum. If several maxima with
 	 *         the same value exist, the cursor is on the first one.
+	 * @implNote op name='stats.max', type=Function
 	 */
 	public static < T extends Comparable< T > > Cursor< T > findMax( final IterableInterval< T > iterable )
 	{

--- a/src/main/java/net/imglib2/algorithm/stats/Min.java
+++ b/src/main/java/net/imglib2/algorithm/stats/Min.java
@@ -46,7 +46,8 @@ public class Min
 {
 	/**
 	 * Find the minimum value and its position in an {@link IterableInterval}.
-	 * 
+	 *
+	 * @implNote op name='stats.min', type=Function
 	 * @param iterable
 	 *            input interval.
 	 * @return a cursor positioned on the global minimum. If several minima with

--- a/src/main/java/net/imglib2/algorithm/stats/Normalize.java
+++ b/src/main/java/net/imglib2/algorithm/stats/Normalize.java
@@ -42,7 +42,8 @@ public class Normalize
 {
 	/**
 	 * Normalize values of an {@link IterableInterval} to the range [min, max].
-	 * 
+	 *
+	 * @implNote op name='image.normalize', type=Inplace1
 	 * @param iterable
 	 *            the interval to be normalized.
 	 * @param min

--- a/src/main/java/net/imglib2/algorithm/util/Grids.java
+++ b/src/main/java/net/imglib2/algorithm/util/Grids.java
@@ -213,6 +213,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code dimensions} and their positions within a cell grid.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param dimensions
 	 * @param blockSize
 	 * @return list of blocks as specified by {@link Interval} and the position
@@ -229,6 +230,7 @@ public class Grids
 	 * specified by {@code min}, {@code max} and their positions within a cell
 	 * grid.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param min
 	 * @param max
 	 * @param blockSize
@@ -245,6 +247,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code dimensions} and their positions within a cell grid.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param dimensions
 	 * @param blockSize
 	 * @return list of blocks as specified by {@link Interval}
@@ -260,6 +263,7 @@ public class Grids
 	 * specified by {@code min}, {@code max} and their positions within a cell
 	 * grid.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param min
 	 * @param max
 	 * @param blockSize
@@ -275,6 +279,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code dimensions}.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param dimensions
 	 * @param blockSize
 	 * @return list of blocks defined by minimum
@@ -289,6 +294,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code dimensions}.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param dimensions
 	 * @param blockSize
 	 * @param func
@@ -306,6 +312,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code min} and {@code max}.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param min
 	 * @param max
 	 * @param blockSize
@@ -321,6 +328,7 @@ public class Grids
 	 * Get all blocks of size {@code blockSize} contained within an interval
 	 * specified by {@code min} and {@code max}.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param min
 	 * @param max
 	 * @param blockSize
@@ -466,6 +474,7 @@ public class Grids
 	 * into a {@link Pair} of {@link Interval} and {@link long[]} that specify
 	 * the block and its position in grid coordinates.
 	 *
+	 * @implNote op name='grid.partition', type=Function
 	 * @param min
 	 *            minimum of the grid
 	 * @param max

--- a/src/main/java/net/imglib2/algorithm/util/ParallelizeOverBlocks.java
+++ b/src/main/java/net/imglib2/algorithm/util/ParallelizeOverBlocks.java
@@ -61,6 +61,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelize', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.
@@ -88,6 +89,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelizeAsync', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.
@@ -112,6 +114,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelize', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.
@@ -145,6 +148,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelizeAsync', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.
@@ -177,6 +181,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelize', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.
@@ -206,6 +211,7 @@ public class ParallelizeOverBlocks
 	 *
 	 * Submit blocked tasks and wait for execution.
 	 *
+	 * @implNote op name='grid.parallelizeAsync', type=Function
 	 * @param func
 	 *            {@link Function} to be applied to each block as specified by
 	 *            first parameter {@link Interval}.


### PR DESCRIPTION
This PR uses [therapi-runtime-javadoc](https://github.com/dnault/therapi-runtime-javadoc) to declare all static functionality in imglib2-alrogithm as Ops. See [this test](https://github.com/scijava/incubator/blob/6d185b1585ceb27adb695b5a52c72ad38e25ad5c/imglib/imglib2-algorithm-optest/src/test/java/net/imglib2/algorithm/optest/OpTest.java#L17) for how these Ops can be called, and the module `imglib/imglib2-algorithm-optest` for an example of the structure required to call these annotated methods as Ops.

A new dependency on `therapi-runtime-javadoc-scribe` is added to the maven compiler plugin. *For now*, this was added to the imglib2-algorithm POM. Once `pom-scijava-base` 15.0.0 is propagated to imglib2-algorithm, we can remove almost everything added to this POM by this PR. 

The only line needed once we depend on that version of `pom-scijava-base` is [this line](https://github.com/imglib/imglib2-algorithm/blob/4f81a788017d76587c73326d2d52367489a59ddf/pom.xml#L203), which is responsible for informing therapi-runtime-javadoc-scribe of the set of packages it should process. This line must be changed once we bump the version, as the property used is under a different name.

Using `therapi-runtime-javadoc-scribe`, JSON files are generated for each file containing javadoc in each package specified by `therapi.packages`

Open questions:
* Op naming: I have not yet come up with a simple answer to this. I thought it would be nice to name the Ops using the method name, but some methods across different classes have the same name. We could name them using a camel-case `"class.method_name"`, which might match well with how these methods would be called from a static context...
* Which packages should be passed to therapi? We could just pass all packages, but this would retain javadoc that would not be used. We could also only pass packages with Op declarations, but it would be easy to forget to add new packages to this property when ops are declared in new packages. I tend to like the latter a little better, but don't feel too strongly.
* What to do with static methods not conforming to an Op? Many static methods are essentially [`org.scijava.function.Computer`](https://github.com/scijava/incubator/blob/main/scijava/scijava-function/src/main/java/org/scijava/function/Computers.java)s with their output parameter in a position that is **not** the last one; for these, I have added another method with a different parameter ordering. Other methods do not conform to Op types, such as the [`HessianMatrix`](https://github.com/imglib/imglib2-algorithm/blob/99ed0d777a2ede9b14501d32e1f8cb6f57368854/src/main/java/net/imglib2/algorithm/gradient/HessianMatrix.java#L91) methods. We could easily write a new `FunctionalInterface` for these guys, but they wouldn't have the support of `OpBuilder`, adaptation, etc.

TODO:
* [x] The build seems to fail in Java 8, but it runs just fine in Java 11. I still need to figure out why that is... :thinking: 