### PR TITLE
Distance transform propagate labels

### DIFF
--- a/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
@@ -738,7 +738,7 @@ public class DistanceTransform
 			final DISTANCE_TYPE distanceType,
 			final double... weights )
 	{
-		final U maxVal = tmp.getType().copy();
+		final U maxVal = tmp.getType().createVariable();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -792,7 +792,7 @@ public class DistanceTransform
 			final int nTasks,
 			final double... weights ) throws InterruptedException, ExecutionException
 	{
-		final U maxVal = tmp.getType().copy();
+		final U maxVal = tmp.getType().createVariable();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -919,7 +919,7 @@ public class DistanceTransform
 			final RandomAccessibleInterval< V > target,
 			final Distance d )
 	{
-		final U maxVal = tmp.getType().copy();
+		final U maxVal = tmp.getType().createVariable();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -966,7 +966,7 @@ public class DistanceTransform
 			final ExecutorService es,
 			final int nTasks ) throws InterruptedException, ExecutionException
 	{
-		final U maxVal = tmp.getType().copy();
+		final U maxVal = tmp.getType().createVariable();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );

--- a/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
@@ -56,7 +56,6 @@ import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.cell.CellImg;
 import net.imglib2.img.cell.CellImgFactory;
-import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.IntegerType;
@@ -83,6 +82,7 @@ import net.imglib2.view.composite.RealComposite;
  * </p>
  *
  * @author Philipp Hanslovsky
+ * @author John Bogovic
  */
 public class DistanceTransform
 {
@@ -393,129 +393,7 @@ public class DistanceTransform
 		transform( source, source, d );
 	}
 
-	/**
-	 * Create
-	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
-	 * transforms of sampled functions</a> on {@code source} using arbitrary
-	 * {@link Distance} d. Intermediate and final results will be stored in
-	 * {@code source} ({@link DoubleType} recommended).
-	 * <p>
-	 * Also propagates a set of input labels so that it contains the nearest label
-	 * everywhere.
-	 *
-	 * @param source
-	 *            Input function on which distance transform should be computed.
-	 * @param labels
-	 *            Labels to be propagated.
-	 * @param d
-	 *            {@link Distance} between two points.
-	 * @param <T>
-	 *            {@link RealType} input
-	 * @param <L>
-	 *            {@link IntegerType} the label type
-	 */
-	public static < T extends RealType< T >, L extends IntegerType< L > > void transformPropagateLabels(
-			final RandomAccessibleInterval< T > source,
-			final RandomAccessibleInterval< L > labels,
-			final DISTANCE_TYPE distanceType )
-	{
-		// TODO generalize distance
-		transformPropagateLabels( source, source, labels, labels, new EuclidianDistanceIsotropic( 1 ) );
-	}
 
-	/**
-	 * Create
-	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
-	 * transforms of sampled functions</a> on {@code source} using arbitrary
-	 * {@link Distance} d. Intermediate and final results will be stored in
-	 * {@code target} ({@link DoubleType} recommended).
-	 *
-	 * @param source
-	 *            Input function on which distance transform should be computed.
-	 * @param target
-	 *            Final result of distance transform.
-	 * @param d
-	 *            {@link Distance} between two points.
-	 * @param <T>
-	 *            {@link RealType} input distance type
-	 * @param <U>
-	 *            {@link RealType} result type
-	 * @param <L>
-	 *            {@link IntegerType} label type
-	 * @param <U>
-	 *            {@link IntegerType} label result type
-	 */
-	public static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType<L>, M extends IntegerType<M> > void transformPropagateLabels(
-			final RandomAccessible< T > source,
-			final RandomAccessibleInterval< U > target,
-			final RandomAccessibleInterval< L > labels,
-			final RandomAccessibleInterval< M > labelsResult,
-			final Distance d )
-	{
-		transformPropagateLabels( source, target, target, labels, labelsResult, d );
-	}
-
-	/**
-	 * Create
-	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
-	 * transforms of sampled functions</a> on {@code source} using arbitrary
-	 * {@link Distance} d. Intermediate results will be stored in {@code tmp}
-	 * ({@link DoubleType} recommended). The output will be written into
-	 * {@code target}.
-	 *
-	 * @param source
-	 *            Input function on which distance transform should be computed.
-	 * @param tmp
-	 *            Storage for intermediate results.
-	 * @param target
-	 *            Final result of distance transform.
-	 * @param d
-	 *            {@link Distance} between two points.
-	 * @param <T>
-	 *            {@link RealType} input
-	 * @param <U>
-	 *            {@link RealType} intermediate results
-	 * @param <V>
-	 *            {@link RealType} output
-	 */
-	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V >, L extends IntegerType<L>, M extends IntegerType<M> > void transformPropagateLabels(
-			final RandomAccessible< T > source,
-			final RandomAccessibleInterval< U > tmp,
-			final RandomAccessibleInterval< V > target,
-			final RandomAccessible< L > labels,
-			final RandomAccessible< M > labelsResult,
-			final Distance d )
-	{
-		assert source.numDimensions() == target.numDimensions(): "Dimension mismatch";
-		final int nDim = source.numDimensions();
-		final int lastDim = nDim - 1;
-
-		if ( nDim == 1 )
-		{
-			transformAlongDimensionPropagateLabels(
-					( RandomAccessible< T > ) Views.addDimension( source ),
-					Views.addDimension( target, 0, 0 ),
-					Views.addDimension( labels ),
-					Views.addDimension( labelsResult ),
-					d, 0 );
-		}
-		else
-		{
-			transformAlongDimensionPropagateLabels( source, tmp, labels, labelsResult, d, 0 );
-		}
-
-		for ( int dim = 1; dim < nDim; ++dim )
-		{
-			if ( dim == lastDim )
-			{
-				transformAlongDimensionPropagateLabels( tmp, target, labels, labelsResult, d, dim );
-			}
-			else
-			{
-				transformAlongDimensionPropagateLabels( tmp, tmp, labels, labelsResult, d, dim );
-			}
-		}
-	}
 
 	/**
 	 * Create
@@ -1095,42 +973,6 @@ public class DistanceTransform
 		transform( converted, tmp, target, d, es, nTasks );
 	}
 
-	@SuppressWarnings( "unchecked" )
-	public static < L extends IntegerType< L >, T extends RealType< T > > RandomAccessibleInterval< T > labelTransform(
-			final RandomAccessibleInterval< L > labels,
-			final DISTANCE_TYPE distanceType,
-			final double... weights )
-	{
-		final RandomAccessibleInterval< DoubleType > distance = Util.getSuitableImgFactory( labels, new DoubleType()).create( labels );
-		distance.getAt( 0 ).setReal( 0 );
-
-		labelTransform( labels, distance, distance, distanceType, weights );
-		return ( RandomAccessibleInterval< T > ) distance;
-	}
-
-	public static < L extends IntegerType< L >, T extends RealType< T > > void labelTransform(
-			final RandomAccessible< L > source,
-			final RandomAccessibleInterval< T > distance,
-			final DISTANCE_TYPE distanceType,
-			final double... weights )
-	{
-		labelTransform( source, distance, distance, distanceType, weights );
-	}
-
-	public static < L extends IntegerType< L >, T extends RealType< T >, U extends RealType< U > > void labelTransform(
-			final RandomAccessible< L > source,
-			final RandomAccessibleInterval< T > tmp,
-			final RandomAccessibleInterval< U > distance,
-			final DISTANCE_TYPE distanceType,
-			final double... weights )
-	{
-		final U maxVal = distance.getType().copy();
-		maxVal.setReal( maxVal.getMaxValue() );
-		final Converter< L, U > converter = new LabelsToCost<>( 0, maxVal );
-		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
-		transform( converted, tmp, distance, distanceType, weights );
-	}
-
 	/**
 	 * Create binary distance transform on {@code source} using L1 distance.
 	 * Intermediate results will be stored in {@code tmp} ({@link DoubleType}
@@ -1325,58 +1167,6 @@ public class DistanceTransform
 		invokeAllAndWait( es, tasks );
 	}
 
-
-	private static < T extends RealType< T >, U extends RealType< U > > void transformSingleColumn(
-			final RealComposite< T > source,
-			final RealComposite< U > target,
-			final RealComposite< LongType > lowerBoundDistanceIndex,
-			final RealComposite< DoubleType > envelopeIntersectLocation,
-			final RealComposite< LongType > nearestLabel,
-			final Distance d,
-			final int dim,
-			final long size )
-	{
-		long k = 0;
-
-		lowerBoundDistanceIndex.get( 0 ).set( 0 );
-		envelopeIntersectLocation.get( 0 ).set( Double.NEGATIVE_INFINITY );
-		envelopeIntersectLocation.get( 1 ).set( Double.POSITIVE_INFINITY );
-		for ( long position = 1; position < size; ++position )
-		{
-			long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-			final double sourceAtPosition = source.get( position ).getRealDouble();
-
-			// the point at which these parabolas intersect
-			double s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
-
-			for ( double envelopeValueAtK = envelopeIntersectLocation.get( k ).get(); s <= envelopeValueAtK; envelopeValueAtK = envelopeIntersectLocation.get( k ).get() )
-			{
-				--k;
-				envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-				s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
-			}
-			++k;
-			lowerBoundDistanceIndex.get( k ).set( position );
-			envelopeIntersectLocation.get( k ).set( s );
-			envelopeIntersectLocation.get( k + 1 ).set( Double.POSITIVE_INFINITY );
-		}
-
-		k = 0;
-
-		for ( long position = 0; position < size; ++position )
-		{
-			while ( envelopeIntersectLocation.get( k + 1 ).get() < position )
-			{
-				++k;
-			}
-			final long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-			// copy necessary because of the following line, access to source
-			// after write to source -> source and target cannot be the same
-			target.get( position ).setReal( d.evaluate( position, envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), dim ) );
-		}
-
-	}
-
 	private static < T extends RealType< T >, U extends RealType< U > > void transformSingleColumn(
 			final RealComposite< T > source,
 			final RealComposite< U > target,
@@ -1421,95 +1211,6 @@ public class DistanceTransform
 			// copy necessary because of the following line, access to source
 			// after write to source -> source and target cannot be the same
 			target.get( position ).setReal( d.evaluate( position, envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), dim ) );
-		}
-
-	}
-
-	private static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType< L >, M extends IntegerType< M > > void transformAlongDimensionPropagateLabels(
-			final RandomAccessible< T > source,
-			final RandomAccessibleInterval< U > target,
-			final RandomAccessible< L > labelSource,
-			final RandomAccessible< M > labelTarget,
-			final Distance d,
-			final int dim )
-	{
-		final int lastDim = target.numDimensions() - 1;
-		final long size = target.dimension( dim );
-		final RealComposite< DoubleType > tmp = Views.collapseReal( createAppropriateOneDimensionalImage( size, new DoubleType() ) ).randomAccess().get();
-
-		// do not permute if we already work on last dimension
-		final Cursor< RealComposite< T > > s = Views.flatIterable( Views.collapseReal( dim == lastDim ? Views.interval( source, target ) : Views.permute( Views.interval( source, target ), dim, lastDim ) ) ).cursor();
-		final Cursor< RealComposite< U > > t = Views.flatIterable( Views.collapseReal( dim == lastDim ? target : Views.permute( target, dim, lastDim ) ) ).cursor();
-
-		final Cursor< RealComposite< L > > ls = Views.flatIterable(
-				Views.collapseReal( dim == lastDim ? Views.interval( labelSource, target ) : Views.permute( Views.interval( labelSource, target ), dim, lastDim ) ) ).cursor();
-
-		final Cursor< RealComposite< M > > lt = Views.flatIterable(
-				Views.collapseReal( dim == lastDim ? Views.interval( labelTarget, target ) : Views.permute( Views.interval( labelTarget, target ), dim, lastDim ) ) ).cursor();
-
-		final RealComposite< LongType > lowerBoundDistanceIndex = Views.collapseReal( createAppropriateOneDimensionalImage( size, new LongType() ) ).randomAccess().get();
-		final RealComposite< DoubleType > envelopeIntersectLocation = Views.collapseReal( createAppropriateOneDimensionalImage( size + 1, new DoubleType() ) ).randomAccess().get();
-
-		while ( s.hasNext() )
-		{
-			final RealComposite< T > sourceComp = s.next();
-			final RealComposite< U > targetComp = t.next();
-			final RealComposite< L > labelComp = ls.next();
-			final RealComposite< M > labelTargetComp = lt.next();
-			for ( long i = 0; i < size; ++i )
-			{
-				tmp.get( i ).set( sourceComp.get( i ).getRealDouble() );
-			}
-			transformSingleColumnPropagateLabels( tmp, targetComp, labelComp, labelTargetComp, lowerBoundDistanceIndex, envelopeIntersectLocation, d, dim, size );
-		}
-	}
-
-	private static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType<L>, M extends IntegerType<M> > void transformSingleColumnPropagateLabels(
-			final RealComposite< T > source,
-			final RealComposite< U > target,
-			final RealComposite< L > labelsSource,
-			final RealComposite< M > labelsResult,
-			final RealComposite< LongType > lowerBoundDistanceIndex,
-			final RealComposite< DoubleType > envelopeIntersectLocation,
-			final Distance d,
-			final int dim,
-			final long size )
-	{
-		long k = 0;
-
-		lowerBoundDistanceIndex.get( 0 ).set( 0 );
-		envelopeIntersectLocation.get( 0 ).set( Double.NEGATIVE_INFINITY );
-		envelopeIntersectLocation.get( 1 ).set( Double.POSITIVE_INFINITY );
-		for ( long position = 1; position < size; ++position )
-		{
-			long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-			final double sourceAtPosition = source.get( position ).getRealDouble();
-			double s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
-
-			for ( double envelopeValueAtK = envelopeIntersectLocation.get( k ).get(); s <= envelopeValueAtK; envelopeValueAtK = envelopeIntersectLocation.get( k ).get() )
-			{
-				--k;
-				envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-				s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
-			}
-			++k;
-			lowerBoundDistanceIndex.get( k ).set( position );
-			envelopeIntersectLocation.get( k ).set( s );
-			envelopeIntersectLocation.get( k + 1 ).set( Double.POSITIVE_INFINITY );
-		}
-
-		k = 0;
-		for ( long position = 0; position < size; ++position )
-		{
-			while ( envelopeIntersectLocation.get( k + 1 ).get() < position )
-			{
-				++k;
-			}
-			final long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
-			// copy necessary because of the following line, access to source
-			// after write to source -> source and target cannot be the same
-			target.get( position ).setReal( d.evaluate( position, envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), dim ) );
-			labelsResult.get( position ).setInteger( labelsSource.get( envelopeIndexAtK ).getIntegerLong() );
 		}
 
 	}
@@ -1626,6 +1327,395 @@ public class DistanceTransform
 		return size > Integer.MAX_VALUE ? new CellImgFactory<>( t, Integer.MAX_VALUE ).create( dim ) : new ArrayImgFactory<>( t ).create( dim );
 	}
 
+	@SuppressWarnings( "unchecked" )
+	public static < L extends IntegerType< L >, T extends RealType< T > > RandomAccessibleInterval< T > labelTransform(
+			final RandomAccessibleInterval< L > labels,
+			final long backgroundLabel,
+			final double... weights )
+	{
+		final RandomAccessibleInterval< DoubleType > distance = makeDistances( backgroundLabel, labels, new DoubleType() );
+		labelTransform( labels, distance, weights );
+		return ( RandomAccessibleInterval< T > ) distance;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public static < L extends IntegerType< L >, T extends RealType< T > > RandomAccessibleInterval< T > labelTransform(
+			final RandomAccessibleInterval< L > labels,
+			final long backgroundLabel,
+			final ExecutorService es,
+			final int nTasks,
+			final double... weights )
+	{
+		final RandomAccessibleInterval< DoubleType > distance = makeDistances( backgroundLabel, labels, new DoubleType() );
+		labelTransform( labels, distance, weights );
+		return ( RandomAccessibleInterval< T > ) distance;
+	}
+
+	/**
+	 * Compute the distance transform, of the given distance image, storing the
+	 * result in place. Simultaneously, modifies the labels image so that the
+	 * value at every point is the closest label, where initial distances are
+	 * given by the values in the distance argument.
+	 *
+	 * @param <L>
+	 *            label type
+	 * @param <T>
+	 *            distance type
+	 * @param labels
+	 *            the label iamge
+	 * @param distance
+	 *            the distance image
+	 * @param weights
+	 *            for distance computation per dimension
+	 */
+	public static < L extends IntegerType< L >, T extends RealType< T > > void labelTransform(
+			final RandomAccessibleInterval< L > labels,
+			final RandomAccessibleInterval< T > distance,
+			final double... weights )
+	{
+		final T maxVal = distance.getType().copy();
+		maxVal.setReal( maxVal.getMaxValue() );
+		final boolean isIsotropic = weights.length <= 1;
+		final double[] w = weights.length == labels.numDimensions() ? weights : DoubleStream.generate( () -> weights.length == 0 ? 1.0 : weights[ 0 ] ).limit( labels.numDimensions() ).toArray();
+
+		// TODO add L1 distance
+		final Distance distanceFun = isIsotropic ? new EuclidianDistanceIsotropic( w[ 0 ] ) : new EuclidianDistanceAnisotropic( w );
+		transformPropagateLabels( distance, distance, distance, labels, labels, distanceFun );
+	}
+
+	public static < L extends IntegerType< L >, T extends RealType< T > > void labelTransform(
+			final RandomAccessibleInterval< L > labels,
+			final RandomAccessibleInterval< T > distance,
+			final ExecutorService es,
+			final int nTasks,
+			final double... weights ) throws InterruptedException, ExecutionException
+	{
+		final T maxVal = distance.getType().copy();
+		maxVal.setReal( maxVal.getMaxValue() );
+		final boolean isIsotropic = weights.length <= 1;
+		final double[] w = weights.length == labels.numDimensions() ? weights : DoubleStream.generate( () -> weights.length == 0 ? 1.0 : weights[ 0 ] ).limit( labels.numDimensions() ).toArray();
+
+		// TODO add L1 distance
+		final Distance distanceFun = isIsotropic ? new EuclidianDistanceIsotropic( w[ 0 ] ) : new EuclidianDistanceAnisotropic( w );
+		transformPropagateLabels( distance, distance, distance, labels, labels, distanceFun, es, nTasks );
+	}
+
+	/**
+	 * Create
+	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
+	 * transforms of sampled functions</a> on {@code source} using arbitrary
+	 * {@link Distance} d. Intermediate and final results will be stored in
+	 * {@code source} ({@link DoubleType} recommended).
+	 * <p>
+	 * Also propagates a set of input labels so that it contains the nearest label
+	 * everywhere.
+	 *
+	 * @param source
+	 *            Input function on which distance transform should be computed.
+	 * @param labels
+	 *            Labels to be propagated.
+	 * @param d
+	 *            {@link Distance} between two points.
+	 * @param <T>
+	 *            {@link RealType} input
+	 * @param <L>
+	 *            {@link IntegerType} the label type
+	 */
+	public static < T extends RealType< T >, L extends IntegerType< L > > void transformPropagateLabels(
+			final RandomAccessibleInterval< T > distance,
+			final RandomAccessibleInterval< L > labels,
+			final DISTANCE_TYPE distanceType )
+	{
+		// TODO generalize distance
+		transformPropagateLabels( distance, distance, labels, labels, new EuclidianDistanceIsotropic( 1 ) );
+	}
+
+	/**
+	 * Create
+	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
+	 * transforms of sampled functions</a> on {@code source} using arbitrary
+	 * {@link Distance} d. Intermediate and final results will be stored in
+	 * {@code target} ({@link DoubleType} recommended).
+	 *
+	 * Simultaneously, modifies the labels image so that the label at every
+	 * point is the closest label, where initial distances are given by the
+	 * values in the distance argument.
+	 */
+	public static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType<L>, M extends IntegerType<M> > void transformPropagateLabels(
+			final RandomAccessible< T > distance,
+			final RandomAccessibleInterval< U > distanceResult,
+			final RandomAccessible< L > labels,
+			final RandomAccessibleInterval< M > labelsResult,
+			final Distance d )
+	{
+		transformPropagateLabels( distance, distanceResult, distanceResult, labels, labelsResult, d );
+	}
+
+	/**
+	 * Create
+	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
+	 * transforms of sampled functions</a> on {@code source} using arbitrary
+	 * {@link Distance} d. Intermediate results will be stored in {@code tmp}
+	 * ({@link DoubleType} recommended). The output will be written into
+	 * {@code target}.
+	 *
+	 * @param source
+	 *            Input function on which distance transform should be computed.
+	 * @param tmp
+	 *            Storage for intermediate results.
+	 * @param target
+	 *            Final result of distance transform.
+	 * @param d
+	 *            {@link Distance} between two points.
+	 * @param <T>
+	 *            {@link RealType} input
+	 * @param <U>
+	 *            {@link RealType} intermediate results
+	 * @param <V>
+	 *            {@link RealType} output
+	 */
+	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V >, L extends IntegerType<L>, M extends IntegerType<M> > void transformPropagateLabels(
+			final RandomAccessible< T > source,
+			final RandomAccessibleInterval< U > tmp,
+			final RandomAccessibleInterval< V > target,
+			final RandomAccessible< L > labels,
+			final RandomAccessibleInterval< M > labelsResult,
+			final Distance d )
+	{
+		assert source.numDimensions() == target.numDimensions(): "Dimension mismatch";
+		final int nDim = source.numDimensions();
+		final int lastDim = nDim - 1;
+
+		if ( nDim == 1 )
+		{
+			transformAlongDimensionPropagateLabels(
+					( RandomAccessible< T > ) Views.addDimension( source ),
+					Views.addDimension( target, 0, 0 ),
+					Views.addDimension( labels ),
+					Views.addDimension( labelsResult ),
+					d, 0 );
+		}
+		else
+		{
+			transformAlongDimensionPropagateLabels( source, tmp, labels, labelsResult, d, 0 );
+		}
+
+		for ( int dim = 1; dim < nDim; ++dim )
+		{
+			if ( dim == lastDim )
+			{
+				transformAlongDimensionPropagateLabels( tmp, target, labels, labelsResult, d, dim );
+			}
+			else
+			{
+				transformAlongDimensionPropagateLabels( tmp, tmp, labels, labelsResult, d, dim );
+			}
+		}
+	}
+
+	/**
+	 * Create
+	 * <a href="http://www.theoryofcomputing.org/articles/v008a019/">distance
+	 * transforms of sampled functions</a> on {@code source} using arbitrary
+	 * {@link Distance} d. Intermediate results will be stored in {@code tmp}
+	 * ({@link DoubleType} recommended). The output will be written into
+	 * {@code target}.
+	 *
+	 * @param source
+	 *            Input function on which distance transform should be computed.
+	 * @param tmp
+	 *            Storage for intermediate results.
+	 * @param target
+	 *            Final result of distance transform.
+	 * @param d
+	 *            {@link Distance} between two points.
+	 * @param <T>
+	 *            {@link RealType} input
+	 * @param <U>
+	 *            {@link RealType} intermediate results
+	 * @param <V>
+	 *            {@link RealType} output
+	 * @throws ExecutionException 
+	 * @throws InterruptedException 
+	 */
+	public static < T extends RealType< T >, U extends RealType< U >, V extends RealType< V >, L extends IntegerType<L>, M extends IntegerType<M> > void transformPropagateLabels(
+			final RandomAccessible< T > source,
+			final RandomAccessibleInterval< U > tmp,
+			final RandomAccessibleInterval< V > target,
+			final RandomAccessible< L > labels,
+			final RandomAccessibleInterval< M > labelsResult,
+			final Distance d,
+			final ExecutorService es,
+			final int nTasks) throws InterruptedException, ExecutionException
+	{
+		assert source.numDimensions() == target.numDimensions(): "Dimension mismatch";
+		final int nDim = source.numDimensions();
+		final int lastDim = nDim - 1;
+
+		if ( nDim == 1 )
+		{
+			transformAlongDimensionPropagateLabels(
+					( RandomAccessible< T > ) Views.addDimension( source ),
+					Views.addDimension( target, 0, 0 ),
+					Views.addDimension( labels ),
+					Views.addDimension( labelsResult ),
+					d, 0 );
+		}
+		else
+		{
+			transformAlongDimensionPropagateLabelsParallel( source, tmp, labels, labelsResult, d, 0, es, nTasks );
+		}
+
+		for ( int dim = 1; dim < nDim; ++dim )
+		{
+			if ( dim == lastDim )
+			{
+				transformAlongDimensionPropagateLabelsParallel( tmp, target, labels, labelsResult, d, dim, es, nTasks);
+			}
+			else
+			{
+				transformAlongDimensionPropagateLabelsParallel( tmp, tmp, labels, labelsResult, d, dim, es, nTasks);
+			}
+		}
+	}
+
+	private static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType< L >, M extends IntegerType< M > > void transformAlongDimensionPropagateLabels(
+			final RandomAccessible< T > source,
+			final RandomAccessibleInterval< U > target,
+			final RandomAccessible< L > labelSource,
+			final RandomAccessible< M > labelTarget,
+			final Distance d,
+			final int dim )
+	{
+		final int lastDim = target.numDimensions() - 1;
+		final long size = target.dimension( dim );
+
+		final Img< DoubleType > tmpImg = createAppropriateOneDimensionalImage( size, new DoubleType() );
+		final RealComposite< DoubleType > tmp = Views.collapseReal( tmpImg ).randomAccess().get();
+
+		final Img< L > tmpLabelImg = Util.getSuitableImgFactory( tmpImg, labelSource.getType() ).create( tmpImg );
+		final RealComposite< L > tmpLabel = Views.collapseReal( tmpLabelImg ).randomAccess().get();
+
+		// do not permute if we already work on last dimension
+		final Cursor< RealComposite< T > > s = Views.flatIterable( Views.collapseReal( dim == lastDim ? Views.interval( source, target ) : Views.permute( Views.interval( source, target ), dim, lastDim ) ) ).cursor();
+		final Cursor< RealComposite< U > > t = Views.flatIterable( Views.collapseReal( dim == lastDim ? target : Views.permute( target, dim, lastDim ) ) ).cursor();
+
+		final Cursor< RealComposite< L > > ls = Views.flatIterable(
+				Views.collapseReal( dim == lastDim ? Views.interval( labelSource, target ) : Views.permute( Views.interval( labelSource, target ), dim, lastDim ) ) ).cursor();
+
+		final Cursor< RealComposite< M > > lt = Views.flatIterable(
+				Views.collapseReal( dim == lastDim ? Views.interval( labelTarget, target ) : Views.permute( Views.interval( labelTarget, target ), dim, lastDim ) ) ).cursor();
+
+		final RealComposite< LongType > lowerBoundDistanceIndex = Views.collapseReal( createAppropriateOneDimensionalImage( size, new LongType() ) ).randomAccess().get();
+		final RealComposite< DoubleType > envelopeIntersectLocation = Views.collapseReal( createAppropriateOneDimensionalImage( size + 1, new DoubleType() ) ).randomAccess().get();
+
+		while ( s.hasNext() )
+		{
+			final RealComposite< T > sourceComp = s.next();
+			final RealComposite< U > targetComp = t.next();
+			final RealComposite< L > labelComp = ls.next();
+			final RealComposite< M > labelTargetComp = lt.next();
+			for ( long i = 0; i < size; ++i )
+			{
+				tmp.get( i ).set( sourceComp.get( i ).getRealDouble() );
+				tmpLabel.get( i ).setInteger( labelComp.get( i ).getIntegerLong() );
+			}
+			transformSingleColumnPropagateLabels( tmp, targetComp, tmpLabel, labelTargetComp, lowerBoundDistanceIndex, envelopeIntersectLocation, d, dim, size );
+		}
+	}
+
+	private static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType<L>, M extends IntegerType<M> > void transformSingleColumnPropagateLabels(
+			final RealComposite< T > source,
+			final RealComposite< U > target,
+			final RealComposite< L > labelsSource,
+			final RealComposite< M > labelsResult,
+			final RealComposite< LongType > lowerBoundDistanceIndex,
+			final RealComposite< DoubleType > envelopeIntersectLocation,
+			final Distance d,
+			final int dim,
+			final long size )
+	{
+		long k = 0;
+
+		lowerBoundDistanceIndex.get( 0 ).set( 0 );
+		envelopeIntersectLocation.get( 0 ).set( Double.NEGATIVE_INFINITY );
+		envelopeIntersectLocation.get( 1 ).set( Double.POSITIVE_INFINITY );
+		for ( long position = 1; position < size; ++position )
+		{
+			long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
+			final double sourceAtPosition = source.get( position ).getRealDouble();
+			double s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
+
+			for ( double envelopeValueAtK = envelopeIntersectLocation.get( k ).get(); s <= envelopeValueAtK; envelopeValueAtK = envelopeIntersectLocation.get( k ).get() )
+			{
+				--k;
+				envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
+				s = d.intersect( envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), position, sourceAtPosition, dim );
+			}
+			++k;
+			lowerBoundDistanceIndex.get( k ).set( position );
+			envelopeIntersectLocation.get( k ).set( s );
+			envelopeIntersectLocation.get( k + 1 ).set( Double.POSITIVE_INFINITY );
+		}
+
+		k = 0;
+		for ( long position = 0; position < size; ++position )
+		{
+			while ( envelopeIntersectLocation.get( k + 1 ).get() < position )
+			{
+				++k;
+			}
+			final long envelopeIndexAtK = lowerBoundDistanceIndex.get( k ).get();
+			// copy necessary because of the following line, access to source
+			// after write to source -> source and target cannot be the same
+			target.get( position ).setReal( d.evaluate( position, envelopeIndexAtK, source.get( envelopeIndexAtK ).getRealDouble(), dim ) );
+			labelsResult.get( position ).setInteger( labelsSource.get( envelopeIndexAtK ).getIntegerLong() );
+		}
+
+	}
+
+	private static < T extends RealType< T >, U extends RealType< U >, L extends IntegerType< L >, M extends IntegerType< M > > void transformAlongDimensionPropagateLabelsParallel(
+			final RandomAccessible< T > source,
+			final RandomAccessibleInterval< U > target,
+			final RandomAccessible< L > labelSource,
+			final RandomAccessible< M > labelTarget,
+			final Distance d,
+			final int dim,
+			final ExecutorService es,
+			final int nTasks ) throws InterruptedException, ExecutionException
+	{
+		int largestDim = getLargestDimension( Views.hyperSlice( target, dim, target.min( dim ) ) );
+		// ignore dimension along which we calculate transform
+		if ( largestDim >= dim )
+		{
+			largestDim += 1;
+		}
+		final long size = target.dimension( dim );
+		final long stepPerChunk = Math.max( size / nTasks, 1 );
+
+		final long[] min = Intervals.minAsLongArray( target );
+		final long[] max = Intervals.maxAsLongArray( target );
+
+		final long largestDimMin = target.min( largestDim );
+		final long largestDimMax = target.max( largestDim );
+
+		final ArrayList< Callable< Void > > tasks = new ArrayList<>();
+		for ( long m = largestDimMin, M = largestDimMin + stepPerChunk - 1; m <= largestDimMax; m += stepPerChunk, M += stepPerChunk )
+		{
+			min[ largestDim ] = m;
+			max[ largestDim ] = Math.min( M, largestDimMax );
+			final Interval fi = new FinalInterval( min, max );
+			tasks.add( () -> {
+				transformAlongDimensionPropagateLabels( source, Views.interval( target, fi ),
+						labelSource, Views.interval( labelTarget, fi ),
+						d, dim );
+				return null;
+			} );
+		}
+
+		invokeAllAndWait( es, tasks );
+	}
+
 	/**
 	 * Convenience method to find largest dimension of {@link Interval}
 	 * interval.
@@ -1638,18 +1728,6 @@ public class DistanceTransform
 	public static int getLargestDimension( final Interval interval )
 	{
 		return IntStream.range( 0, interval.numDimensions() ).mapToObj( i -> new ValuePair<>( i, interval.dimension( i ) ) ).max( ( p1, p2 ) -> Long.compare( p1.getB(), p2.getB() ) ).get().getA();
-	}
-
-	private static <L extends IntegerType< L >, M extends IntegerType< M > > RandomAccessibleInterval< M > makeLabels(
-			final RandomAccessibleInterval< L > labels,
-			final M type) {
-
-		final RandomAccessibleInterval< M > propagedLabels = Util.getSuitableImgFactory( labels, type ).create( labels );
-		LoopBuilder.setImages( labels, propagedLabels ).forEachPixel( (s,d) -> {
-			d.setInteger( s.getIntegerLong() );
-		});
-
-		return ( RandomAccessibleInterval< M > ) propagedLabels;
 	}
 
 	private static < L extends IntegerType< L >, T extends RealType< T > > RandomAccessibleInterval< T > makeDistances(
@@ -1684,30 +1762,6 @@ public class DistanceTransform
 		public void convert( final B input, final R output )
 		{
 			output.set( input.get() ? zero : maxValForR );
-		}
-
-	}
-
-	private static class LabelsToCost< L extends IntegerType< L >, R extends RealType< R > > implements Converter< L, R >
-	{
-		private final R maxValForR;
-
-		private final R zero;
-
-		private final long label;
-
-		public LabelsToCost( final long label, final R maxValForR )
-		{
-			this.maxValForR = maxValForR;
-			this.label = label;
-			this.zero = maxValForR.createVariable();
-			zero.setZero();
-		}
-
-		@Override
-		public void convert( final L input, final R output )
-		{
-			output.set( input.getIntegerLong() == label ? zero : maxValForR );
 		}
 
 	}

--- a/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
@@ -528,7 +528,7 @@ public class DistanceTransform
 		{
 			transformAlongDimension(
 					( RandomAccessible< T > ) Views.addDimension( source ),
-					Views.interval( Views.addDimension( target ), new FinalInterval( target.dimension( 0 ), 1 ) ),
+					Views.addDimension( target, 0, 0 ),
 					d,
 					0 );
 		}
@@ -601,7 +601,7 @@ public class DistanceTransform
 		{
 			transformAlongDimensionParallel(
 					( RandomAccessible< T > ) Views.addDimension( source ),
-					Views.interval( Views.addDimension( target ), new FinalInterval( target.dimension( 0 ), 1 ) ),
+					Views.addDimension( target, 0, 0 ),
 					d,
 					0,
 					es,
@@ -734,8 +734,7 @@ public class DistanceTransform
 			final DISTANCE_TYPE distanceType,
 			final double... weights )
 	{
-
-		final U maxVal = Util.getTypeFromInterval( tmp ).createVariable();
+		final U maxVal = tmp.getType().copy();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -789,7 +788,7 @@ public class DistanceTransform
 			final int nTasks,
 			final double... weights ) throws InterruptedException, ExecutionException
 	{
-		final U maxVal = Util.getTypeFromInterval( tmp ).createVariable();
+		final U maxVal = tmp.getType().copy();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -916,7 +915,7 @@ public class DistanceTransform
 			final RandomAccessibleInterval< V > target,
 			final Distance d )
 	{
-		final U maxVal = Util.getTypeFromInterval( tmp ).createVariable();
+		final U maxVal = tmp.getType().copy();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -963,7 +962,7 @@ public class DistanceTransform
 			final ExecutorService es,
 			final int nTasks ) throws InterruptedException, ExecutionException
 	{
-		final U maxVal = Util.getTypeFromInterval( tmp ).createVariable();
+		final U maxVal = tmp.getType().copy();
 		maxVal.setReal( maxVal.getMaxValue() );
 		final Converter< B, U > converter = new BinaryMaskToCost<>( maxVal );
 		final RandomAccessible< U > converted = Converters.convert( source, converter, maxVal.createVariable() );
@@ -1005,7 +1004,7 @@ public class DistanceTransform
 		{
 			transformL1AlongDimension(
 					( RandomAccessible< T > ) Views.addDimension( source ),
-					Views.interval( Views.addDimension( target ), new FinalInterval( target.dimension( 0 ), 1 ) ),
+					Views.addDimension( target, 0, 0 ),
 					0,
 					weights[ 0 ] );
 		}
@@ -1073,7 +1072,7 @@ public class DistanceTransform
 		{
 			transformL1AlongDimensionParallel(
 					( RandomAccessible< T > ) Views.addDimension( source ),
-					Views.interval( Views.addDimension( target ), new FinalInterval( target.dimension( 0 ), 1 ) ),
+					Views.addDimension( target, 0, 0 ),
 					0,
 					weights[ 0 ],
 					es,

--- a/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
+++ b/src/main/java/net/imglib2/algorithm/morphology/distance/DistanceTransform.java
@@ -1466,15 +1466,12 @@ public class DistanceTransform
 	 *            the label type
 	 * @param labels
 	 *            the label image
-	 * @param backgroundLabel
-	 *            the background label
 	 * @param es
 	 *            the ExecutorService
 	 * @param nTasks
 	 *            the number of tasks in which to split the computation 
 	 * @param weights
 	 *            for distance computation per dimension
-	 * @return the distance map
 	 * @throws ExecutionException 
 	 * @throws InterruptedException 
 	 */
@@ -1529,7 +1526,7 @@ public class DistanceTransform
 	 * distances are given by the values in the distance argument. Results of
 	 * label propagation are stored in {@code labelsResult}
 	 * <p>
-	 * This implementation uses the {@targetDistance} for temporary storage.
+	 * This implementation uses the {@code targetDistance} for temporary storage.
 	 *
 	 * @param <T>
 	 *            input distance {@link RealType}
@@ -1542,8 +1539,6 @@ public class DistanceTransform
 	 * @param distance
 	 *            Input distance function from which distance transform should
 	 *            be computed.
-	 * @param tmpDistance
-	 *            Storage for intermediate distance results.
 	 * @param targetDistance
 	 *            Final result of distance transform. May be the same instance
 	 *            as distance.

--- a/src/test/java/net/imglib2/algorithm/morphology/distance/DistanceTransformTest.java
+++ b/src/test/java/net/imglib2/algorithm/morphology/distance/DistanceTransformTest.java
@@ -35,6 +35,7 @@
 package net.imglib2.algorithm.morphology.distance;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -487,7 +488,15 @@ public class DistanceTransformTest
 			final int numLabels = params.getIntPosition( 2 );
 
 			testLabelPropagationHelper( numDimensions, numLabels );
-			testLabelPropagationHelperParallel( numDimensions, numLabels );
+			try
+			{
+				testLabelPropagationHelperParallel( numDimensions, numLabels );
+			}
+			catch ( Exception e )
+			{
+				e.printStackTrace();
+				fail();
+			}
 		} );
 
 	}
@@ -507,7 +516,7 @@ public class DistanceTransformTest
 		final ArrayImg< LongType, LongArray > labels = ArrayImgs.longs( imgDims );
 
 		final Set< PointAndLabel > points = initializeLabels( rng, nLabels, labels );
-		DistanceTransform.labelTransform( labels, 0 );
+		DistanceTransform.voronoiDistanceTransform( labels, 0 );
 		validateLabelsSet( "serial", points, labels );
 	}
 
@@ -518,14 +527,16 @@ public class DistanceTransformTest
 	 *
 	 * @param ndims number of dimensions
 	 * @param nLabels number of labels
+	 * @throws ExecutionException 
+	 * @throws InterruptedException 
 	 */
-	private void testLabelPropagationHelperParallel( int ndims, int nLabels )
+	private void testLabelPropagationHelperParallel( int ndims, int nLabels ) throws InterruptedException, ExecutionException
 	{
 
 		final long[] imgDims = LongStream.iterate( dimensionSize, d -> d - 1 ).limit( ndims ).toArray();
 		final ArrayImg< LongType, LongArray > labels = ArrayImgs.longs( imgDims );
 		final Set< PointAndLabel > points = initializeLabels( rng, nLabels, labels );
-		DistanceTransform.labelTransform( labels, 0, es, 3 * nThreads );
+		DistanceTransform.voronoiDistanceTransform( labels, 0, es, 3 * nThreads );
 		validateLabelsSet( "parallel", points, labels );
 	}
 


### PR DESCRIPTION
Working toward propagating a set of labels while performing a distance transform.

`transformPropagateLabels(distance, labels, distanceType)`

behaves identically to `transform` with respect to the `distance` argument, but also
modifies the input labels such that the label at any given point is given by the label
with the closes distance to that point (where the distances are given by 

For example, for 1D inputs `distance` and `labels` given by:
```
distance = [ 9.0, 9.0, 1.0, 9.0, 9.0, 9.0,  1.5, 9.0 ]  
labels   = [   4,   2,   1,   0,   8,   0,    2,   0 ]
```
will modify labels to be:
```
labels   = [   1,   1,   1,   1,   1,   2,    2,   2 ]
```